### PR TITLE
⚡ Bolt: Fix & optimize range filters

### DIFF
--- a/articles/bolt-journal.md
+++ b/articles/bolt-journal.md
@@ -1,3 +1,7 @@
 ## 2026-01-17 - [Optimizing count queries with WP_Query vs wpdb]
 **Learning:** `WP_Query` with `posts_per_page => -1` hydrates all post objects, which is extremely memory intensive and slow when only a count is needed. Even with `fields => 'ids'`, it still loads all IDs into memory.
 **Action:** When only a count is needed, especially for meta queries, use `$wpdb->get_var` with `COUNT(*)` (or `COUNT(DISTINCT ID)`) to avoid object hydration and reduce memory usage significantly.
+
+## 2026-01-18 - [Optimizing Heavy Range Filters]
+**Learning:** Functions that fetch and process all posts (like `jobus_all_range_field_value` which unserializes meta for every job) can become massive bottlenecks if not guarded by checks for active user input. In this case, a nonce check was also preventing the feature from working, but fixing the nonce without adding the guard would have caused severe performance degradation on all searches.
+**Action:** Always check if a heavy filter is actually active (via `$_GET` or specific params) before triggering the expensive data fetching logic.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -764,7 +764,7 @@ function jobus_all_range_field_value(): array {
     $post_ids    = [];
     $jobus_nonce = ! empty( $_GET['jobus_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['jobus_nonce'] ) ) : '';
 
-    if ( $jobus_nonce && wp_verify_nonce( $jobus_nonce, 'jobus_search_nonce' ) ) {
+    if ( $jobus_nonce && wp_verify_nonce( $jobus_nonce, 'jobus_search_filter' ) ) {
 
         $filter_widgets = jobus_opt( 'job_sidebar_widgets' );
         $search_widgets = [];

--- a/templates/includes/archive-template-loader.php
+++ b/templates/includes/archive-template-loader.php
@@ -284,17 +284,29 @@ function jobus_process_range_filters( $filter_widgets ) {
 		return $result_ids;
 	}
 
-	$all_slider_values = jobus_all_range_field_value();
-	if ( empty( $all_slider_values ) ) {
-		return $result_ids;
-	}
-
-	// Process range matching logic
+	// Bolt Optimization: Check if any range widgets actually have active input before fetching all values
+	// This prevents the heavy jobus_all_range_field_value query on default archive loads
+	$has_active_range_filter = false;
 	$price_ranged = array();
+
 	foreach ( $search_widgets as $input ) {
 		$min_price = jobus_search_terms( $input )[0] ?? '';
 		$max_price = jobus_search_terms( $input )[1] ?? '';
+
+		if ( '' !== $min_price || '' !== $max_price ) {
+			$has_active_range_filter = true;
+		}
+
 		$price_ranged[ $input ] = array( $min_price, $max_price );
+	}
+
+	if ( ! $has_active_range_filter ) {
+		return $result_ids;
+	}
+
+	$all_slider_values = jobus_all_range_field_value();
+	if ( empty( $all_slider_values ) ) {
+		return $result_ids;
 	}
 
 	$formatted_price_ranged = array();


### PR DESCRIPTION
⚡ Bolt: Optimized range filter performance

💡 **What:** 
1. Fixed a bug where `jobus_all_range_field_value` used the wrong nonce action (`jobus_search_nonce` instead of `jobus_search_filter`), causing range filters to fail silently.
2. Implemented a performance guard in `jobus_process_range_filters` to only execute the heavy `jobus_all_range_field_value` function when range filter inputs are actually present in the request.

🎯 **Why:** 
The `jobus_all_range_field_value` function fetches `jobus_meta_options` for ALL published jobs and unserializes them in PHP. This is an extremely heavy operation (O(n) where n is total jobs). Previously, fixing the nonce bug would have exposed this bottleneck on every search/archive load. Now, it only runs when necessary (when a user explicitly filters by range).

📊 **Impact:** 
Eliminates a massive database query and PHP processing loop on all default job archive page loads and keyword searches.

✅ **Testing:** 
- Verified logic with standalone reproduction script `tests/repro_range_filter.php`.
- Confirmed nonce mismatch via code inspection.
- Confirmed guard logic correctly skips execution when inputs are missing.

🔌 **Compatibility:** 
Works with existing frontend forms and Jobus Pro features.

---
*PR created automatically by Jules for task [15573878239323071119](https://jules.google.com/task/15573878239323071119) started by @mdjwel*