### PR TITLE
⚡ Bolt: Optimize company job count query with caching

### DIFF
--- a/articles/bolt-journal.md
+++ b/articles/bolt-journal.md
@@ -5,3 +5,11 @@
 ## 2026-01-17 - [Hidden Heavy Query in Archive Loader]
 **Learning:** `jobus_all_range_field_value()` fetches and unserializes `jobus_meta_options` for *all* published jobs/candidates whenever range widgets are present in the sidebar, even if no search is actually performed by the user. This causes massive overhead on simple archive page views.
 **Action:** Always check if the user has provided input for a filter before running expensive queries to fetch data for that filter. In `jobus_process_range_filters`, skip the heavy DB call if no range filter inputs are present in `$_GET`.
+
+## 2026-01-17 - [Redundant Querying in Template Loops]
+**Learning:** `jobus_get_selected_company_count` was being called twice per company in archive loops (once for count, once for link), triggering two separate DB queries. The second call (`posts_per_page => -1`) was particularly heavy as it fetched all job IDs.
+**Action:** When a function provides related data (like count and link) that requires the same underlying query, cache the result of the "heavier" query (e.g., fetching IDs) and use it to serve both requests, significantly reducing DB hits in loops.
+
+## 2026-01-17 - [Caching Empty States]
+**Learning:** When caching query results, using `empty($cached_data['ids'])` to validate the cache can fail if the valid result is an empty set (e.g., 0 jobs). This causes the code to treat the valid empty result as "missing cache" and re-query unnecessarily.
+**Action:** Use `!isset()` to check for cache existence, or explicitly check for `false` if `get_transient` is used, to ensure that valid empty results are respected and served from cache.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -542,32 +542,48 @@ if ( ! function_exists( 'jobus_job_archive_query' ) ) {
  */
 if ( ! function_exists( 'jobus_get_selected_company_count' ) ) {
     function jobus_get_selected_company_count( $company_id, $link = true ): int|string {
-        $args = array(
-                'post_type'      => 'jobus_job',
-                'posts_per_page' => $link ? - 1 : 1,
-                'fields'         => 'ids',
-                'meta_query'     => array(
-                        'relation' => 'AND', // Optional, defaults to "AND
-                        array(
-                                'key'     => 'jobus_meta_options',
-                                'value'   => $company_id,
-                                'compare' => 'LIKE',
-                        ),
-                )
-        );
+        $transient_key = 'jobus_company_job_data_' . $company_id;
+        $cached_data   = get_transient( $transient_key );
 
-        $job_posts = new \WP_Query( $args );
+        // If cache is missing, or if link is requested but IDs are missing (though we always fetch IDs now)
+        if ( false === $cached_data || ( $link && ! isset( $cached_data['ids'] ) ) ) {
+            $args = array(
+                    'post_type'              => 'jobus_job',
+                    'posts_per_page'         => - 1,
+                    'fields'                 => 'ids',
+                    'no_found_rows'          => true,
+                    'update_post_meta_cache' => false,
+                    'update_post_term_cache' => false,
+                    'meta_query'             => array(
+                            'relation' => 'AND', // Optional, defaults to "AND
+                            array(
+                                    'key'     => 'jobus_meta_options',
+                                    'value'   => $company_id,
+                                    'compare' => 'LIKE',
+                            ),
+                    )
+            );
+
+            $job_posts = new \WP_Query( $args );
+
+            $cached_data = array(
+                    'count' => count( $job_posts->posts ),
+                    'ids'   => $job_posts->posts
+            );
+
+            set_transient( $transient_key, $cached_data, HOUR_IN_SECONDS );
+        }
 
         // if a link false, then return only count
         if ( ! $link ) {
-            return $job_posts->found_posts;
+            return $cached_data['count'];
         } else {
 
-            $company_ids_arr   = $job_posts->posts;
+            $company_ids_arr   = $cached_data['ids'];
             $company_ids_array = implode( ',', $company_ids_arr );
 
             // if post counts 1 then return a post-link
-            if ( $job_posts->found_posts == 1 ) {
+            if ( $cached_data['count'] == 1 ) {
                 return get_permalink( $company_ids_array );
             } else {
                 return get_post_type_archive_link( 'jobus_job' ) . '?search_type=company_search&company_ids=' . $company_ids_array;


### PR DESCRIPTION
⚡ **Optimized Company Job Count Query**

### 💡 What
Modified `jobus_get_selected_company_count` in `includes/functions.php` to cache the results of the expensive meta query used to find jobs belonging to a company.

### 🎯 Why
The function was previously called twice per company in archive loops (once for the count, once for the link), triggering two separate database queries. The second query often requested all posts (`posts_per_page => -1`), which is heavy. This caused N+1 (actually 2N+1) query issues on company archive pages.

### 📊 Impact
*   **Reduces DB Queries:** Drops queries from 2 per company to 0 (cached) or 1 (uncached) per company.
*   **Memory Usage:** Uses `fields => 'ids'` and disables cache updates to significantly reduce memory footprint during the query.

### 🔬 Measurement
Verified with a standalone test script simulating WordPress environment:
*   Initial load: 1 query (optimized).
*   Subsequent calls: 0 queries (served from cache).
*   Zero-result case: Correctly cached and served (0 queries).

### ✅ Testing
*   Tested `jobus_get_selected_company_count` in isolation with mock `WP_Query`.
*   Verified correct behavior for companies with jobs and companies with 0 jobs.
*   Verified that the "Link" output matches the expected format using cached data.

---
*PR created automatically by Jules for task [3658287809828353713](https://jules.google.com/task/3658287809828353713) started by @mdjwel*