### PR TITLE
⚡ Bolt: Cache sidebar filter counts

### DIFF
--- a/articles/bolt-journal.md
+++ b/articles/bolt-journal.md
@@ -5,3 +5,7 @@
 ## 2026-01-17 - [Hidden Heavy Query in Archive Loader]
 **Learning:** `jobus_all_range_field_value()` fetches and unserializes `jobus_meta_options` for *all* published jobs/candidates whenever range widgets are present in the sidebar, even if no search is actually performed by the user. This causes massive overhead on simple archive page views.
 **Action:** Always check if the user has provided input for a filter before running expensive queries to fetch data for that filter. In `jobus_process_range_filters`, skip the heavy DB call if no range filter inputs are present in `$_GET`.
+
+## 2026-01-17 - [Transient Caching for N+1 Sidebar Counts]
+**Learning:** Sidebar filter widgets (checkboxes/dropdowns) iterate through all options and call `jobus_count_meta_key_usage` for each one, causing dozens of expensive `LIKE` queries per page load.
+**Action:** Wrap these count queries in `get_transient` caching (1 hour) using a hashed key of the parameters to eliminate repetitive DB hits on subsequent page loads.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -437,6 +437,15 @@ if ( ! function_exists( 'jobus_count_meta_key_usage' ) ) {
     function jobus_count_meta_key_usage( $post_type = 'jobus_job', $meta_key = '', $meta_value = '' ): int {
         global $wpdb;
 
+        // Generate cache key
+        $cache_key = 'jobus_mk_cnt_' . md5( $post_type . $meta_key . $meta_value );
+
+        // Check for cached value
+        $cached_count = get_transient( $cache_key );
+        if ( false !== $cached_count ) {
+            return (int) $cached_count;
+        }
+
         // Use direct SQL for performance
         $query = "
             SELECT COUNT(DISTINCT p.ID)
@@ -457,6 +466,9 @@ if ( ! function_exists( 'jobus_count_meta_key_usage' ) ) {
             $meta_key,
             $like_value
         ) );
+
+        // Cache the result for 1 hour
+        set_transient( $cache_key, $count, 3600 );
 
         return (int) $count;
     }


### PR DESCRIPTION
💡 **What:** Implemented transient caching for the `jobus_count_meta_key_usage` function in `includes/functions.php`.
🎯 **Why:** Sidebar filter widgets (dropdowns/checkboxes) call this function for *every* option to display the post count, causing dozens of expensive `LIKE` queries per page load.
📊 **Impact:** Reduces database queries significantly on job archive pages with filters. A sidebar with 5 filters each having 5 options would previously trigger 25+ queries; now it triggers 0 (after cache warming) for 1 hour.
🔬 **Measurement:** Confirmed logic via `tests/test_jobus_count.php` (mocked environment).
✅ **Testing:** Verified syntax and logic.
🔌 **Compatibility:** Uses standard WordPress Transients API, compatible with all caching plugins.

---
*PR created automatically by Jules for task [4944928511533396864](https://jules.google.com/task/4944928511533396864) started by @mdjwel*