### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in job application removal

### DIFF
--- a/articles/sentinel-journal.md
+++ b/articles/sentinel-journal.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The candidate resume upload form used `wp_handle_upload` without specifying allowed MIME types. This meant any file type allowed by WordPress (including images, audio, video) could be uploaded as a resume, potentially leading to storage abuse or confusion, even if not direct RCE (since WP blocks PHP by default).
 **Learning:** `wp_handle_upload` defaults to `get_allowed_mime_types()`, which is broad. Specific file inputs (like resumes) must explicitly define their allowed MIME types using the `mimes` override parameter to enforce business logic and security depth.
 **Prevention:** Always define a strict whitelist of allowed MIME types when handling specific file uploads using `wp_handle_upload`.
+
+## 2026-01-17 - IDOR in Application Deletion due to Weak Ownership Verification
+**Vulnerability:** The `remove_job_application` AJAX handler verified permission by matching the user's email to the `candidate_email` meta field. This allowed any user with a matching email (spoofed or shared) to delete another user's application.
+**Learning:** Relying on mutable or unverified strings (like email addresses stored in meta) for authorization is insecure. Users can potentially manipulate these fields or their own profile to impersonate ownership.
+**Prevention:** Always verify object ownership using immutable, trusted identifiers like `post_author` or `user_id` when performing destructive actions.

--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -213,9 +213,10 @@ class Ajax_Actions {
 			wp_send_json_error();
 		}
 
-		$user              = wp_get_current_user();
-		$application_email = get_post_meta( $application_id, 'candidate_email', true );
-		if ( $user->user_email !== $application_email ) {
+		$user = wp_get_current_user();
+		// Security Fix: Verify ownership by post author instead of email matching to prevent IDOR.
+		// Also allow administrators to delete.
+		if ( (int) $application->post_author !== $user->ID && ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error();
 		}
 


### PR DESCRIPTION
This PR fixes a critical Insecure Direct Object Reference (IDOR) vulnerability in the `remove_job_application` AJAX handler.

Previously, the handler allowed any logged-in user to delete a job application if their email address matched the `candidate_email` stored in the application's metadata. This was insecure because email addresses in metadata are not strict proof of ownership and could potentially be spoofed or matched by another user.

**Changes:**
- Modified `includes/Classes/Ajax_Actions.php`:
    - Removed the check comparing `$user->user_email` to `$application_email`.
    - Added a strict check comparing `(int) $application->post_author` to `$user->ID`.
    - Added an exception to allow users with `manage_options` capability (Administrators) to delete applications regardless of ownership.

**Verification:**
- Verified using a custom reproduction script (`tests/repro_idor.php`) that mocked WordPress environment.
- Confirmed that:
    - Users can delete their own applications.
    - Users CANNOT delete other users' applications even if emails match.
    - Administrators can delete any application.
- Checked for syntax errors using `php -l`.

**Security Impact:**
- Prevents attackers from deleting legitimate job applications by manipulating email addresses or exploiting shared email scenarios.
- Enforces strict ownership based on the immutable `post_author` ID.

---
*PR created automatically by Jules for task [9769106304703688624](https://jules.google.com/task/9769106304703688624) started by @mdjwel*