### PR TITLE
⚡ Bolt: Cache meta key usage counts

### DIFF
--- a/articles/bolt-journal.md
+++ b/articles/bolt-journal.md
@@ -5,3 +5,7 @@
 ## 2026-01-17 - [Hidden Heavy Query in Archive Loader]
 **Learning:** `jobus_all_range_field_value()` fetches and unserializes `jobus_meta_options` for *all* published jobs/candidates whenever range widgets are present in the sidebar, even if no search is actually performed by the user. This causes massive overhead on simple archive page views.
 **Action:** Always check if the user has provided input for a filter before running expensive queries to fetch data for that filter. In `jobus_process_range_filters`, skip the heavy DB call if no range filter inputs are present in `$_GET`.
+
+## 2026-01-17 - [Testing Pitfall: Redeclaring PHP built-ins]
+**Learning:** When writing standalone verification scripts, ensure that standard PHP functions (e.g., `is_array`, `headers_sent`, `setcookie`) are not redeclared as mocks, as this causes fatal errors.
+**Action:** Check if a function exists or is a built-in before mocking it, or rely on namespaced mocks if possible.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -442,6 +442,15 @@ if ( ! function_exists( 'jobus_count_meta_key_usage' ) ) {
     function jobus_count_meta_key_usage( $post_type = 'jobus_job', $meta_key = '', $meta_value = '' ): int {
         global $wpdb;
 
+        // Generate a unique cache key
+        $cache_key = 'jobus_mk_cnt_' . md5( $post_type . '|' . $meta_key . '|' . $meta_value );
+
+        // Check for cached value
+        $cached_count = get_transient( $cache_key );
+        if ( false !== $cached_count ) {
+            return (int) $cached_count;
+        }
+
         // Use direct SQL for performance
         $query = "
             SELECT COUNT(DISTINCT p.ID)
@@ -462,6 +471,9 @@ if ( ! function_exists( 'jobus_count_meta_key_usage' ) ) {
             $meta_key,
             $like_value
         ) );
+
+        // Cache the result for 1 hour
+        set_transient( $cache_key, $count, HOUR_IN_SECONDS );
 
         return (int) $count;
     }


### PR DESCRIPTION
Implements transient caching for `jobus_count_meta_key_usage` to reduce database load on archive pages with filters. This optimization replaces repeated direct database queries with cached results, significantly improving performance on pages with multiple sidebar filter widgets.

---
*PR created automatically by Jules for task [7063735864916686024](https://jules.google.com/task/7063735864916686024) started by @mdjwel*