### PR TITLE
⚡ Bolt: Cache meta key usage counts to reduce DB queries

### DIFF
--- a/articles/bolt-journal.md
+++ b/articles/bolt-journal.md
@@ -5,3 +5,7 @@
 ## 2026-01-17 - [Hidden Heavy Query in Archive Loader]
 **Learning:** `jobus_all_range_field_value()` fetches and unserializes `jobus_meta_options` for *all* published jobs/candidates whenever range widgets are present in the sidebar, even if no search is actually performed by the user. This causes massive overhead on simple archive page views.
 **Action:** Always check if the user has provided input for a filter before running expensive queries to fetch data for that filter. In `jobus_process_range_filters`, skip the heavy DB call if no range filter inputs are present in `$_GET`.
+
+## 2026-01-17 - [Transient Caching for Faceted Search Counts]
+**Learning:** `jobus_count_meta_key_usage` runs a direct SQL query for every filter option in the sidebar (N+1 query issue). This causes significant database load on archive pages.
+**Action:** Wrap these expensive count queries in `get_transient` / `set_transient` with a unique key based on the query arguments. This reduces N queries to 0 (after cache warmup) on subsequent page loads.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -442,6 +442,15 @@ if ( ! function_exists( 'jobus_count_meta_key_usage' ) ) {
     function jobus_count_meta_key_usage( $post_type = 'jobus_job', $meta_key = '', $meta_value = '' ): int {
         global $wpdb;
 
+        // Create a unique cache key
+        $cache_key = 'jobus_mk_cnt_' . md5( $post_type . '|' . $meta_key . '|' . $meta_value );
+
+        // Check for cached value
+        $cached_count = get_transient( $cache_key );
+        if ( false !== $cached_count ) {
+            return (int) $cached_count;
+        }
+
         // Use direct SQL for performance
         $query = "
             SELECT COUNT(DISTINCT p.ID)
@@ -462,6 +471,9 @@ if ( ! function_exists( 'jobus_count_meta_key_usage' ) ) {
             $meta_key,
             $like_value
         ) );
+
+        // Cache the result for 1 hour
+        set_transient( $cache_key, $count, HOUR_IN_SECONDS );
 
         return (int) $count;
     }


### PR DESCRIPTION
Implements transient caching for `jobus_count_meta_key_usage` in `includes/functions.php`.

This addresses a performance bottleneck where archive pages with search filters would trigger dozens of identical SQL queries to count posts for each filter option. By caching these counts for 1 hour, we reduce database load and improve page generation time.

**Testing:**
- Verified with a reproduction script (`tests/reproduce_bottleneck.php`) that the original code executed 10 queries for 10 calls.
- Verified with a validation script (`tests/verify_optimization.php`) that the optimized code executes only 1 query for 10 calls.
- Confirmed cache keys are unique to the arguments provided.

---
*PR created automatically by Jules for task [1106176635211089104](https://jules.google.com/task/1106176635211089104) started by @mdjwel*