### PR TITLE
Refiner: Implement daily auto-expiration for jobs past deadline

### DIFF
--- a/Admin/csf/options/job_opt.php
+++ b/Admin/csf/options/job_opt.php
@@ -89,6 +89,33 @@ CSF::createSection( $settings_prefix, array(
 ) );
 
 
+// Job Expiration
+CSF::createSection( $settings_prefix, array(
+	'parent' => 'jobus_job',
+	'title'  => esc_html__( 'Job Expiration', 'jobus' ),
+	'id'     => 'job_expiration',
+	'fields' => array(
+		array(
+			'id'       => 'enable_auto_expire',
+			'type'     => 'switcher',
+			'title'    => esc_html__( 'Enable Auto Expiration', 'jobus' ),
+			'subtitle' => esc_html__( 'Automatically change job status to draft when the deadline is passed.', 'jobus' ),
+			'default'  => false,
+		),
+
+		array(
+			'id'       => 'auto_expire_batch_size',
+			'type'     => 'number',
+			'title'    => esc_html__( 'Batch Size', 'jobus' ),
+			'subtitle' => esc_html__( 'Number of jobs to process per daily run.', 'jobus' ),
+			'default'  => 50,
+			'min'      => 1,
+			'max'      => 500,
+			'dependency' => array( 'enable_auto_expire', '==', 'true' ),
+		),
+	)
+) );
+
 // Job Archive Page Layout Settings
 CSF::createSection( $settings_prefix, array(
 	'parent' => 'jobus_job',

--- a/includes/Classes/Cron_Manager.php
+++ b/includes/Classes/Cron_Manager.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Cron Manager for Jobus Plugin
+ *
+ * Handles scheduled tasks and automation.
+ *
+ * @package Jobus\Classes
+ * @since   1.6.1
+ */
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Cron_Manager
+ */
+class Cron_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'jobus_auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Register scheduled events.
+	 *
+	 * @return void
+	 */
+	public static function register_events(): void {
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+	}
+
+	/**
+	 * Clear scheduled events.
+	 *
+	 * @return void
+	 */
+	public static function clear_events(): void {
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+	}
+
+	/**
+	 * Auto expire jobs past deadline.
+	 *
+	 * @return void
+	 */
+	public function jobus_auto_expire_jobs(): void {
+		// Get options
+		$options = get_option( 'jobus_opt', [] );
+		$enable  = $options['enable_auto_expire'] ?? false;
+
+		// Check if enabled
+		if ( ! $enable ) {
+			return;
+		}
+
+		// Get batch size
+		$batch_size = isset( $options['auto_expire_batch_size'] ) ? absint( $options['auto_expire_batch_size'] ) : 50;
+		if ( $batch_size < 1 ) {
+			$batch_size = 50;
+		}
+
+		// Query for expired jobs
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => current_time( 'Y-m-d' ),
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+			],
+			'fields'         => 'ids',
+		] );
+
+		if ( empty( $expired_jobs ) ) {
+			return;
+		}
+
+		foreach ( $expired_jobs as $job_id ) {
+			// Update post status to draft
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			// Fire action hook
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -251,6 +252,9 @@ final class Jobus {
 			set_transient( 'jobus_activation_redirect', '1', 60 );
 		}
 
+		// Register cron events
+		\jobus\includes\Classes\Cron_Manager::register_events();
+
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
 	}
@@ -261,6 +265,9 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		// Clear cron events
+		\jobus\includes\Classes\Cron_Manager::clear_events();
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
Implemented an automated workflow to draft jobs that have passed their deadline.
- Added `Cron_Manager` class to handle scheduled tasks.
- Added settings to enable/disable auto-expiration and configure batch size.
- Hooked into `jobus_daily_maintenance` to run the expiration logic daily.
- Added `jobus_job_auto_expired` hook for future extensibility (e.g., notifications).

---
*PR created automatically by Jules for task [4000313551667249414](https://jules.google.com/task/4000313551667249414) started by @mdjwel*