### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/Admin/csf/options/job_opt.php
+++ b/Admin/csf/options/job_opt.php
@@ -88,6 +88,36 @@ CSF::createSection( $settings_prefix, array(
 	)
 ) );
 
+// Job Expiration
+CSF::createSection( $settings_prefix, array(
+	'parent' => 'jobus_job',
+	'title'  => esc_html__( 'Job Expiration', 'jobus' ),
+	'id'     => 'job_expiration',
+	'fields' => array(
+		array(
+			'type'    => 'subheading',
+			'content' => esc_html__( 'Job Expiration Settings', 'jobus' ),
+		),
+		array(
+			'id'       => 'enable_auto_expire',
+			'type'     => 'switcher',
+			'title'    => esc_html__( 'Enable Auto Expiration', 'jobus' ),
+			'subtitle' => esc_html__( 'Automatically change job status to draft when the deadline passes.', 'jobus' ),
+			'default'  => false,
+		),
+		array(
+			'id'         => 'auto_expire_batch_size',
+			'type'       => 'number',
+			'title'      => esc_html__( 'Batch Size', 'jobus' ),
+			'subtitle'   => esc_html__( 'Number of jobs to process per run. Adjust if you encounter timeouts.', 'jobus' ),
+			'default'    => 50,
+			'min'        => 1,
+			'max'        => 500,
+			'dependency' => array( 'enable_auto_expire', '==', 'true' ),
+		),
+	)
+) );
+
 
 // Job Archive Page Layout Settings
 CSF::createSection( $settings_prefix, array(

--- a/includes/Classes/Cron_Manager.php
+++ b/includes/Classes/Cron_Manager.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Cron Manager Class
+ *
+ * Handles scheduled tasks for the Jobus plugin.
+ *
+ * @package Jobus
+ */
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Cron_Manager
+ */
+class Cron_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'jobus_auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Register scheduled events.
+	 *
+	 * @return void
+	 */
+	public static function register_events() {
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+	}
+
+	/**
+	 * Clear scheduled events.
+	 *
+	 * @return void
+	 */
+	public static function clear_events() {
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+	}
+
+	/**
+	 * Auto expire jobs that are past their deadline.
+	 *
+	 * @return void
+	 */
+	public function jobus_auto_expire_jobs() {
+		// Get options
+		$options = get_option( 'jobus_opt', [] );
+		$enable  = isset( $options['enable_auto_expire'] ) && $options['enable_auto_expire'];
+
+		if ( ! $enable ) {
+			return;
+		}
+
+		$batch_size = isset( $options['auto_expire_batch_size'] ) ? absint( $options['auto_expire_batch_size'] ) : 50;
+		if ( $batch_size < 1 ) {
+			$batch_size = 50;
+		}
+
+		$current_date = current_time( 'Y-m-d' );
+
+		// Query for expired jobs
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => $current_date,
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+			],
+			'fields'         => 'ids',
+		] );
+
+		if ( ! empty( $expired_jobs ) ) {
+			foreach ( $expired_jobs as $job_id ) {
+				wp_update_post( [
+					'ID'          => $job_id,
+					'post_status' => 'draft',
+				] );
+
+				/**
+				 * Fires when a job is automatically expired.
+				 *
+				 * @param int $job_id The ID of the expired job.
+				 */
+				do_action( 'jobus_job_auto_expired', $job_id );
+			}
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -251,6 +252,9 @@ final class Jobus {
 			set_transient( 'jobus_activation_redirect', '1', 60 );
 		}
 
+		// Register cron events
+		\jobus\includes\Classes\Cron_Manager::register_events();
+
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
 	}
@@ -261,6 +265,9 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		// Clear cron events
+		\jobus\includes\Classes\Cron_Manager::clear_events();
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
Implemented a daily cron job to automatically expire jobs that have passed their deadline.

### Changes:
1.  **New Class:** `includes/Classes/Cron_Manager.php` handles the scheduling and execution of the `jobus_daily_maintenance` event.
2.  **Settings:** Added a "Job Expiration" section in `Job Options` settings (`Admin/csf/options/job_opt.php`) with:
    *   `enable_auto_expire`: Toggle to enable the feature (default: false).
    *   `auto_expire_batch_size`: Number of jobs to process per run (default: 50).
3.  **Core Integration:** Updated `jobus.php` to:
    *   Register the cron event on plugin activation.
    *   Clear the cron event on plugin deactivation.
    *   Instantiate the `Cron_Manager` class.
4.  **Extensibility:** Fires `jobus_job_auto_expired` action hook for each expired job, allowing Pro version or other plugins to trigger notifications.

### Verification:
*   Verified logic using a standalone PHP script mocking WordPress functions (`tests/verify_cron_logic.php`).
*   Ran `php -l` to ensure no syntax errors.
*   Confirmed batch processing and action firing logic through tests.

---
*PR created automatically by Jules for task [15705514622932445562](https://jules.google.com/task/15705514622932445562) started by @mdjwel*