### PR TITLE
Add auto-expire jobs cron workflow

### DIFF
--- a/Admin/csf/options/job_opt.php
+++ b/Admin/csf/options/job_opt.php
@@ -88,6 +88,31 @@ CSF::createSection( $settings_prefix, array(
 	)
 ) );
 
+// Job Expiration
+CSF::createSection( $settings_prefix, array(
+	'parent' => 'jobus_job',
+	'title'  => esc_html__( 'Job Expiration', 'jobus' ),
+	'id'     => 'job_expiration',
+	'fields' => array(
+		array(
+			'id'      => 'enable_auto_expire',
+			'type'    => 'switcher',
+			'title'   => esc_html__( 'Enable Auto Expiration', 'jobus' ),
+			'label'   => esc_html__( 'Automatically set expired jobs to draft status.', 'jobus' ),
+			'default' => false,
+		),
+		array(
+			'id'       => 'auto_expire_batch_size',
+			'type'     => 'number',
+			'title'    => esc_html__( 'Batch Size', 'jobus' ),
+			'subtitle' => esc_html__( 'Number of jobs to process per run.', 'jobus' ),
+			'default'  => 50,
+			'min'      => 1,
+			'max'      => 100,
+		),
+	),
+) );
+
 
 // Job Archive Page Layout Settings
 CSF::createSection( $settings_prefix, array(

--- a/includes/Classes/Cron_Manager.php
+++ b/includes/Classes/Cron_Manager.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Cron Manager Class
+ *
+ * Handles scheduled tasks for the Jobus plugin.
+ */
+class Cron_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialize hooks.
+	 */
+	public function init() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'jobus_auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Register scheduled events.
+	 *
+	 * @return void
+	 */
+	public static function register_events() {
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+	}
+
+	/**
+	 * Clear scheduled events.
+	 *
+	 * @return void
+	 */
+	public static function clear_events() {
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+	}
+
+	/**
+	 * Auto expire jobs that are past their deadline.
+	 *
+	 * @return void
+	 */
+	public function jobus_auto_expire_jobs() {
+		$options = get_option( 'jobus_opt', [] );
+		$enable_auto_expire = isset( $options['enable_auto_expire'] ) ? $options['enable_auto_expire'] : false;
+
+		if ( ! $enable_auto_expire ) {
+			return;
+		}
+
+		$batch_size = isset( $options['auto_expire_batch_size'] ) ? absint( $options['auto_expire_batch_size'] ) : 50;
+		if ( $batch_size < 1 ) {
+			$batch_size = 50;
+		}
+
+		$current_date = current_time( 'Y-m-d' );
+
+		// We need to check if job_deadline is valid date format
+		// Assuming job_deadline is stored as Y-m-d based on Admin/Dashboard.php usage
+
+		$args = array(
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => array(
+				array(
+					'key'     => 'job_deadline',
+					'value'   => $current_date,
+					'compare' => '<',
+					'type'    => 'DATE',
+				),
+			),
+			'no_found_rows'  => true,
+		);
+
+		$expired_jobs = get_posts( $args );
+
+		if ( ! empty( $expired_jobs ) ) {
+			foreach ( $expired_jobs as $job_id ) {
+				wp_update_post( array(
+					'ID'          => $job_id,
+					'post_status' => 'draft',
+				) );
+
+				/**
+				 * Fires when a job is automatically expired.
+				 *
+				 * @param int $job_id The ID of the expired job.
+				 */
+				do_action( 'jobus_job_auto_expired', $job_id );
+			}
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -253,6 +254,9 @@ final class Jobus {
 
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
+
+		// Schedule daily cron
+		\jobus\includes\Classes\Cron_Manager::register_events();
 	}
 
 	/**
@@ -271,6 +275,9 @@ final class Jobus {
 				update_option( 'jobus_pages', $pages );
 			}
 		}
+
+		// Clear scheduled cron
+		\jobus\includes\Classes\Cron_Manager::clear_events();
 	}
 
 	/**


### PR DESCRIPTION
Implemented an automated workflow to set jobs to 'draft' status when they pass their deadline. This eliminates manual cleanup for administrators. The feature is controlled via a new 'Job Expiration' section in the Job Options settings, where it can be enabled/disabled and the batch size configured. A new action hook `jobus_job_auto_expired` is fired for each expired job to allow for notifications or further processing.

---
*PR created automatically by Jules for task [16427660598122965571](https://jules.google.com/task/16427660598122965571) started by @mdjwel*