### PR TITLE
Add auto-expire jobs functionality via daily cron

### DIFF
--- a/Admin/csf/options/job_opt.php
+++ b/Admin/csf/options/job_opt.php
@@ -89,6 +89,30 @@ CSF::createSection( $settings_prefix, array(
 ) );
 
 
+// Job Expiration
+CSF::createSection( $settings_prefix, array(
+	'parent' => 'jobus_job',
+	'title'  => esc_html__( 'Job Expiration', 'jobus' ),
+	'id'     => 'jobus_job_expiration',
+	'fields' => array(
+		array(
+			'id'       => 'enable_auto_expire',
+			'type'     => 'switcher',
+			'title'    => esc_html__( 'Enable Auto Expire', 'jobus' ),
+			'subtitle' => esc_html__( 'Automatically change status of jobs to "Draft" when they pass their deadline.', 'jobus' ),
+			'default'  => false,
+		),
+		array(
+			'id'         => 'auto_expire_batch_size',
+			'type'       => 'number',
+			'title'      => esc_html__( 'Batch Size', 'jobus' ),
+			'subtitle'   => esc_html__( 'Number of jobs to process per run.', 'jobus' ),
+			'default'    => 50,
+			'dependency' => array( 'enable_auto_expire', '==', true ),
+		),
+	),
+) );
+
 // Job Archive Page Layout Settings
 CSF::createSection( $settings_prefix, array(
 	'parent' => 'jobus_job',

--- a/includes/Classes/Cron_Manager.php
+++ b/includes/Classes/Cron_Manager.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Class Cron_Manager
+ *
+ * Handles scheduled tasks and cron jobs for the Jobus plugin.
+ */
+class Cron_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Hook the cron action
+		add_action( 'jobus_daily_maintenance', [ $this, 'jobus_auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Register scheduled events on activation.
+	 *
+	 * @return void
+	 */
+	public static function register_events(): void {
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+	}
+
+	/**
+	 * Clear scheduled events on deactivation.
+	 *
+	 * @return void
+	 */
+	public static function clear_events(): void {
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+	}
+
+	/**
+	 * Auto-expire jobs that have passed their deadline.
+	 *
+	 * @return void
+	 */
+	public function jobus_auto_expire_jobs(): void {
+		// Check if auto-expire is enabled in settings
+		$options = get_option( 'jobus_opt', [] );
+		if ( empty( $options['enable_auto_expire'] ) ) {
+			return;
+		}
+
+		// Get batch size (default to 50)
+		$batch_size = ! empty( $options['auto_expire_batch_size'] ) ? absint( $options['auto_expire_batch_size'] ) : 50;
+		if ( $batch_size < 1 ) {
+			$batch_size = 50;
+		}
+
+		// Find expired jobs
+		$current_date = current_time( 'Y-m-d' );
+
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => $current_date,
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+			],
+		] );
+
+		if ( empty( $expired_jobs ) ) {
+			return;
+		}
+
+		foreach ( $expired_jobs as $job_id ) {
+			// Update post status to draft
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			/**
+			 * Fires after a job has been automatically expired.
+			 *
+			 * @since 1.6.1
+			 * @param int $job_id The ID of the job that expired.
+			 */
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -163,6 +163,7 @@ final class Jobus {
 		$enable_company   = $options['enable_company'] ?? true;
 
 		// Classes
+		new \jobus\includes\Classes\Cron_Manager();
 		new \jobus\includes\Classes\Ajax_Actions();
 
 		// Submission Classes
@@ -239,6 +240,8 @@ final class Jobus {
 	 * @return void
 	 */
 	public function activate(): void {
+		\jobus\includes\Classes\Cron_Manager::register_events();
+
 		// Insert the installation time into the database.
 		$installed = get_option( 'jobus_installed' );
 		if ( ! $installed ) {
@@ -261,6 +264,8 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		\jobus\includes\Classes\Cron_Manager::clear_events();
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
Implemented an automated workflow to expire jobs that have passed their deadline. 

**Changes:**
1.  **New Class `Cron_Manager`**: Created `includes/Classes/Cron_Manager.php` to handle the `jobus_daily_maintenance` cron event.
2.  **Auto-Expire Logic**: The `jobus_auto_expire_jobs` method queries jobs with `job_deadline` older than the current date and updates their status to `draft`.
3.  **Settings**: Added "Job Expiration" section to Job Options in `Admin/csf/options/job_opt.php`, allowing admins to enable/disable the feature and control the batch size.
4.  **Integration**: Updated `jobus.php` to register the cron event on activation, clear it on deactivation, and instantiate the `Cron_Manager` class.

**Verification:**
- Verified logic using a standalone test script `tests/test_cron_manager.php` which mocked WordPress functions (`get_posts`, `wp_update_post`, `get_option`, etc.).
- Confirmed that `wp_schedule_event` is called on activation and `wp_clear_scheduled_hook` on deactivation.
- Confirmed that jobs past the deadline are correctly identified and updated.
- Linted all modified files.

**Time Saved:**
Eliminates the need for daily/weekly manual review of expired listings, saving admins estimated 15-30 minutes per week depending on volume.

---
*PR created automatically by Jules for task [11254825577057000288](https://jules.google.com/task/11254825577057000288) started by @mdjwel*