### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/Admin/csf/options/job_opt.php
+++ b/Admin/csf/options/job_opt.php
@@ -479,3 +479,27 @@ CSF::createSection( $settings_prefix, array(
 	)
 ) );
 
+// Job Expiration Settings
+CSF::createSection( $settings_prefix, array(
+	'parent' => 'jobus_job',
+	'title'  => esc_html__( 'Job Expiration', 'jobus' ),
+	'id'     => 'job_expiration',
+	'fields' => array(
+		array(
+			'id'       => 'enable_auto_expire',
+			'type'     => 'switcher',
+			'title'    => esc_html__( 'Auto Expire Jobs', 'jobus' ),
+			'subtitle' => esc_html__( 'Automatically change status of jobs past their deadline to "Draft".', 'jobus' ),
+			'default'  => true,
+		),
+		array(
+			'id'       => 'auto_expire_batch_size',
+			'type'     => 'number',
+			'title'    => esc_html__( 'Batch Size', 'jobus' ),
+			'subtitle' => esc_html__( 'Number of jobs to process per day. Reduce if you experience timeouts.', 'jobus' ),
+			'default'  => 50,
+			'min'      => 1,
+			'max'      => 500,
+		),
+	)
+) );

--- a/includes/Classes/Cron_Manager.php
+++ b/includes/Classes/Cron_Manager.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Class Cron_Manager
+ *
+ * Handles scheduled cron tasks.
+ */
+class Cron_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'jobus_auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Auto expire jobs that are past their deadline.
+	 */
+	public function jobus_auto_expire_jobs() {
+		// Check if auto-expire is enabled
+		$options = get_option( 'jobus_opt', [] );
+		$enable  = $options['enable_auto_expire'] ?? true;
+
+		if ( ! $enable ) {
+			return;
+		}
+
+		$batch_size = isset( $options['auto_expire_batch_size'] ) ? absint( $options['auto_expire_batch_size'] ) : 50;
+
+		// Ensure batch size is at least 1
+		if ( $batch_size < 1 ) {
+			$batch_size = 50;
+		}
+
+		$today = current_time( 'Y-m-d' );
+
+		$expired_jobs = get_posts( array(
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'meta_query'     => array(
+				array(
+					'key'     => 'job_deadline',
+					'value'   => $today,
+					'compare' => '<',
+					'type'    => 'DATE',
+				),
+			),
+			'fields'         => 'ids',
+		) );
+
+		if ( ! empty( $expired_jobs ) ) {
+			foreach ( $expired_jobs as $job_id ) {
+				// Update post status to draft
+				wp_update_post( array(
+					'ID'          => $job_id,
+					'post_status' => 'draft',
+				) );
+
+				/**
+				 * Fires after a job has been auto-expired.
+				 *
+				 * @param int $job_id The ID of the job that expired.
+				 */
+				do_action( 'jobus_job_auto_expired', $job_id );
+			}
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -253,6 +254,11 @@ final class Jobus {
 
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
+
+		// Schedule cron events
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
 	}
 
 	/**
@@ -261,6 +267,9 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		// Clear scheduled cron events
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
This PR implements a daily cron job to automatically set jobs to 'draft' status if they have passed their deadline. It includes:
1. A new `Cron_Manager` class that hooks into `jobus_daily_maintenance`.
2. New settings in Job Options > Job Expiration to enable/disable the feature and control batch size.
3. Scheduling logic in the main plugin class (`jobus.php`).
4. Extensible hook `jobus_job_auto_expired` for Pro/addons.
5. Unit verification of the expiration logic.

This addresses the "Automation gaps" priority by automating the manual task of expiring old jobs.

---
*PR created automatically by Jules for task [14870186708448240729](https://jules.google.com/task/14870186708448240729) started by @mdjwel*