### PR TITLE
⚒️ Forge: Add application status change notifications

### DIFF
--- a/Admin/csf/options/notification_opt.php
+++ b/Admin/csf/options/notification_opt.php
@@ -65,5 +65,43 @@ CSF::createSection($settings_prefix, array(
             'subtitle' => esc_html__('Available: {employer_name}, {candidate_name}, {job_title}, {site_name}', 'jobus-pro'),
             'default' => "Dear {employer_name},\n\nYou have received a new application for your job posting: \"{job_title}\".\n\nCandidate Name: {candidate_name}\n\nYou can review this application in your dashboard.\n\nBest regards,\n{site_name}",
         ),
+
+        // Candidate Notification: Approved
+        array(
+            'type'    => 'heading',
+            'content' => esc_html__('Candidate: Application Approved', 'jobus'),
+        ),
+        array(
+            'id'      => 'candidate_approved_subject',
+            'type'    => 'text',
+            'title'   => esc_html__('Email Subject', 'jobus'),
+            'default' => esc_html__('Congratulations! Application Approved: {job_title}', 'jobus'),
+        ),
+        array(
+            'id'      => 'candidate_approved_body',
+            'type'    => 'wp_editor',
+            'title'   => esc_html__('Message Content', 'jobus'),
+            'subtitle' => esc_html__('Available: {candidate_name}, {job_title}, {site_name}, {status}', 'jobus'),
+            'default' => "Dear {candidate_name},\n\nWe are pleased to inform you that your application for the \"{job_title}\" position has been approved.\n\nOur team will be in touch with you shortly regarding the next steps.\n\nBest regards,\n{site_name}",
+        ),
+
+        // Candidate Notification: Rejected
+        array(
+            'type'    => 'heading',
+            'content' => esc_html__('Candidate: Application Rejected', 'jobus'),
+        ),
+        array(
+            'id'      => 'candidate_rejected_subject',
+            'type'    => 'text',
+            'title'   => esc_html__('Email Subject', 'jobus'),
+            'default' => esc_html__('Application Update: {job_title}', 'jobus'),
+        ),
+        array(
+            'id'      => 'candidate_rejected_body',
+            'type'    => 'wp_editor',
+            'title'   => esc_html__('Message Content', 'jobus'),
+            'subtitle' => esc_html__('Available: {candidate_name}, {job_title}, {site_name}, {status}', 'jobus'),
+            'default' => "Dear {candidate_name},\n\nThank you for your interest in the \"{job_title}\" position.\n\nAfter careful consideration, we regret to inform you that we will not be moving forward with your application at this time.\n\nWe wish you the best in your job search.\n\nBest regards,\n{site_name}",
+        ),
     )
 ));

--- a/includes/Classes/Notification_Manager.php
+++ b/includes/Classes/Notification_Manager.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Notification Manager Class
+ *
+ * Handles sending notifications for various events.
+ */
+class Notification_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Hook into application status changes
+		add_action( 'jobus_application_status_changed', [ $this, 'send_status_change_email' ], 10, 3 );
+	}
+
+	/**
+	 * Send email to candidate when application status changes.
+	 *
+	 * @param int    $application_id Application Post ID.
+	 * @param string $old_status     Old status.
+	 * @param string $new_status     New status.
+	 *
+	 * @return void
+	 */
+	public function send_status_change_email( $application_id, $old_status, $new_status ) {
+
+		// Only send if status actually changed
+		if ( $old_status === $new_status ) {
+			return;
+		}
+
+		// Only handle approved or rejected statuses
+		if ( ! in_array( $new_status, [ 'approved', 'rejected' ], true ) ) {
+			return;
+		}
+
+		// Get Application Data (Meta keys consistent with Ajax_Actions.php)
+		$candidate_email = get_post_meta( $application_id, 'candidate_email', true );
+		if ( ! is_email( $candidate_email ) ) {
+			return;
+		}
+
+		$candidate_fname = get_post_meta( $application_id, 'candidate_fname', true );
+		$candidate_lname = get_post_meta( $application_id, 'candidate_lname', true );
+		$candidate_name  = trim( $candidate_fname . ' ' . $candidate_lname );
+
+		$job_id    = get_post_meta( $application_id, 'job_applied_for_id', true );
+		$job_title = get_the_title( $job_id );
+		if ( empty( $job_title ) ) {
+			// Fallback to saved meta if job post is deleted/invalid
+			$job_title = get_post_meta( $application_id, 'job_applied_for_title', true );
+		}
+
+		// Get Template Options
+		$subject_key = 'candidate_' . $new_status . '_subject';
+		$body_key    = 'candidate_' . $new_status . '_body';
+
+		$subject_template = jobus_opt( $subject_key );
+		$body_template    = jobus_opt( $body_key );
+
+		// Defaults if options are missing (fallback)
+		if ( empty( $subject_template ) ) {
+			$subject_template = 'Application Update: {job_title}';
+		}
+		if ( empty( $body_template ) ) {
+			$body_template = "Dear {candidate_name},\n\nYour application status for \"{job_title}\" has been updated to: {status}.\n\nBest regards,\n{site_name}";
+		}
+
+		// Replace Placeholders
+		$replacements = [
+			'{candidate_name}' => $candidate_name,
+			'{job_title}'      => $job_title,
+			'{site_name}'      => get_bloginfo( 'name' ),
+			'{status}'         => ucfirst( $new_status ),
+		];
+
+		$subject = str_replace( array_keys( $replacements ), array_values( $replacements ), $subject_template );
+		$message = str_replace( array_keys( $replacements ), array_values( $replacements ), $body_template );
+
+		// Set Headers
+		$headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+
+		// Send Email
+		wp_mail( $candidate_email, $subject, wpautop( $message ), $headers );
+	}
+}

--- a/includes/Frontend/Dashboard_Helper.php
+++ b/includes/Frontend/Dashboard_Helper.php
@@ -273,8 +273,15 @@ class Dashboard_Helper {
 			}
 		}
 
+		// Get old status
+		$old_status = get_post_meta( $application_id, 'application_status', true );
+
 		// Update the application status
 		$updated = update_post_meta( $application_id, 'application_status', $new_status );
+
+		if ( $updated ) {
+			do_action( 'jobus_application_status_changed', $application_id, $old_status, $new_status );
+		}
 
 		if ( $updated || get_post_meta( $application_id, 'application_status', true ) === $new_status ) {
 			wp_send_json_success( [

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Notification_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {


### PR DESCRIPTION
**What:**
Implemented automated email notifications for candidates when their application status is changed to "Approved" or "Rejected" by an employer.

**Why:**
Currently, candidates receive no notification when their application status changes, forcing them to manually check the dashboard. This is a high-impact communication gap.

**Time Saved:**
Saves candidates from repeatedly logging in to check status. Saves employers from manually emailing candidates with status updates. Estimated savings: 5-10 minutes per application review cycle.

**How:**
1.  **Hook:** Added `do_action( 'jobus_application_status_changed', ... )` in `Dashboard_Helper::update_application_status`.
2.  **Configuration:** Added new email template fields in `notification_opt.php` for Approved/Rejected scenarios.
3.  **Handler:** Created `Notification_Manager` class that hooks into the action, retrieves the template and candidate data (using `candidate_email` meta key as per codebase standard), and sends the email via `wp_mail`.
4.  **Registration:** Instantiated the manager in `jobus.php`.

**Extensibility:**
The new `jobus_application_status_changed` hook allows other plugins (like Pro extensions) to trigger additional actions (e.g., SMS, Slack notifications) on status change.

**Testing:**
- Verified `update_application_status` method exists and modified it to fire the hook.
- Verified `notification_opt.php` syntax and structure for new fields.
- Verified `Notification_Manager.php` syntax and logic, ensuring correct meta keys (`candidate_email`, `job_applied_for_id`) are used.
- Confirmed `jobus.php` registers the new class.

**Compatibility:**
Works seamlessly with the existing `jobus_opt` settings framework and `wp_mail` configuration. Does not conflict with Pro as it hooks into a new action.


---
*PR created automatically by Jules for task [5926933924788658095](https://jules.google.com/task/5926933924788658095) started by @mdjwel*