### PR TITLE
⚒️ Forge: Prevent duplicate job applications

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,29 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Check for duplicate application
+		$duplicate_application = get_posts( [
+			'post_type'      => 'jobus_applicant',
+			'post_status'    => 'any',
+			'posts_per_page' => 1,
+			'meta_query'     => [
+				[
+					'key'   => 'candidate_email',
+					'value' => $candidate_email,
+				],
+				[
+					'key'   => 'job_applied_for_id',
+					'value' => $job_application_id,
+				],
+			],
+			'fields'         => 'ids',
+		] );
+
+		if ( ! empty( $duplicate_application ) ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+			wp_die();
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
* 💡 **What:** Added a validation check in `Ajax_Actions.php` to prevent candidates from applying to the same job multiple times.
* 🎯 **Why:** previously, candidates could submit unlimited applications to the same job, creating spam and clutter for employers.
* ⏱️ **Time Saved:** Saves employers time manually filtering duplicate submissions.
* 🔧 **How:** Implemented a `get_posts` check for existing `jobus_applicant` posts with matching `candidate_email` and `job_applied_for_id` before insertion.
* ✅ **Testing:** Verified with `tests/test_duplicate_application.php` (mocked WP environment) that duplicates are blocked while new applications proceed.
* 🔄 **Compatibility:** Uses existing meta keys (`candidate_email`, `job_applied_for_id`) confirmed in the codebase.

---
*PR created automatically by Jules for task [15659695133628984677](https://jules.google.com/task/15659695133628984677) started by @mdjwel*