### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/Admin/csf/options/job_opt.php
+++ b/Admin/csf/options/job_opt.php
@@ -89,6 +89,30 @@ CSF::createSection( $settings_prefix, array(
 ) );
 
 
+// Job Expiration Settings
+CSF::createSection( $settings_prefix, array(
+	'parent' => 'jobus_job',
+	'title'  => esc_html__( 'Job Expiration', 'jobus' ),
+	'id'     => 'jobus_job_expiration',
+	'fields' => array(
+		array(
+			'id'       => 'enable_auto_expire',
+			'type'     => 'switcher',
+			'title'    => esc_html__( 'Auto-expire Jobs', 'jobus' ),
+			'subtitle' => esc_html__( 'Automatically set jobs to "Draft" status when they pass their expiration date.', 'jobus' ),
+			'default'  => true,
+		),
+		array(
+			'id'         => 'auto_expire_batch_size',
+			'type'       => 'number',
+			'title'      => esc_html__( 'Batch Size', 'jobus' ),
+			'subtitle'   => esc_html__( 'Number of jobs to process per cron run (prevent timeouts).', 'jobus' ),
+			'default'    => 50,
+			'dependency' => array( 'enable_auto_expire', '==', true ),
+		),
+	)
+) );
+
 // Job Archive Page Layout Settings
 CSF::createSection( $settings_prefix, array(
 	'parent' => 'jobus_job',

--- a/includes/Classes/Cron_Manager.php
+++ b/includes/Classes/Cron_Manager.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Cron Manager Class
+ *
+ * Handles scheduled tasks and automation for the Jobus plugin.
+ *
+ * @package Jobus\Classes
+ * @since   1.6.0
+ */
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Cron_Manager
+ *
+ * Manages daily maintenance and other scheduled tasks.
+ */
+class Cron_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Automatically expire jobs that have passed their deadline.
+	 *
+	 * This method runs daily via the 'jobus_daily_maintenance' hook.
+	 * It checks for published jobs with a 'job_deadline' meta value earlier than the current date.
+	 * Qualifying jobs are set to 'draft' status.
+	 *
+	 * @return void
+	 */
+	public function auto_expire_jobs(): void {
+		// get options
+		$options          = get_option( 'jobus_opt', [] );
+		$enable_auto_expire = isset( $options['enable_auto_expire'] ) ? $options['enable_auto_expire'] : true;
+
+		// 1. Check if auto-expire is enabled in settings (default: true).
+		if ( ! $enable_auto_expire ) {
+			return;
+		}
+
+		// 2. Get batch size to prevent timeouts (default: 50).
+		$batch_size = isset( $options['auto_expire_batch_size'] ) ? (int) $options['auto_expire_batch_size'] : 50;
+
+		// 3. Query for expired jobs.
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => current_time( 'Y-m-d' ),
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+			],
+		] );
+
+		// 4. Process each expired job.
+		if ( ! empty( $expired_jobs ) ) {
+			foreach ( $expired_jobs as $job_id ) {
+				// Update post status to draft.
+				wp_update_post( [
+					'ID'          => $job_id,
+					'post_status' => 'draft',
+				] );
+
+				/**
+				 * Fires immediately after a job has been automatically expired.
+				 *
+				 * @param int $job_id The ID of the expired job.
+				 */
+				do_action( 'jobus_job_auto_expired', $job_id );
+			}
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -239,6 +240,11 @@ final class Jobus {
 	 * @return void
 	 */
 	public function activate(): void {
+		// Schedule daily maintenance cron if not already scheduled.
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+
 		// Insert the installation time into the database.
 		$installed = get_option( 'jobus_installed' );
 		if ( ! $installed ) {
@@ -261,6 +267,9 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		// Clear scheduled cron events.
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
Implemented an automated workflow to expire jobs that have passed their deadline.

**Key Changes:**
*   **New Class:** `includes/Classes/Cron_Manager.php` handles the logic.
*   **Cron Event:** `jobus_daily_maintenance` is scheduled daily on plugin activation.
*   **Settings:** Added a "Job Expiration" section to Job Options to enable/disable the feature and set batch size.
*   **Hook:** `jobus_job_auto_expired` action fires when a job is expired, allowing for notifications (e.g., in Pro version).
*   **Optimization:** Uses batch processing (default 50 posts) to prevent timeouts.

**Verification:**
*   Validated syntax with `php -l`.
*   Verified logic with a standalone PHP script mocking WordPress environment, confirming query construction, status updates, and action firing.


---
*PR created automatically by Jules for task [17802787550972939470](https://jules.google.com/task/17802787550972939470) started by @mdjwel*