### PR TITLE
⚒️ Forge: Prevent duplicate job applications

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,33 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Prevent duplicate applications
+		$prevent_duplicate = apply_filters( 'jobus_prevent_duplicate_applications', true );
+		if ( $prevent_duplicate ) {
+			$existing_application = get_posts( [
+				'post_type'      => 'jobus_applicant',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'meta_query'     => [
+					'relation' => 'AND',
+					[
+						'key'   => 'candidate_email',
+						'value' => $candidate_email,
+					],
+					[
+						'key'   => 'job_applied_for_id',
+						'value' => $job_application_id,
+					],
+				],
+			] );
+
+			if ( ! empty( $existing_application ) ) {
+				wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+				wp_die();
+			}
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
⚒️ Forge: Prevent duplicate job applications

* 💡 What: Added duplicate application prevention logic to the `job_application_form` AJAX handler.
* 🎯 Why: Candidates could submit multiple applications to the same job, creating noisy dashboards and wasted effort for employers.
* ⏱️ Time Saved: Eliminates manual deduplication of applications.
* 🔧 How: Queries `jobus_applicant` posts by `candidate_email` and `job_applied_for_id` before insertion.
* 🔌 Extensibility: Added `jobus_prevent_duplicate_applications` filter to allow admins/pro-features to disable the check.
* ✅ Testing: Tested with standalone WP environment mock script.
* 🔄 Compatibility: Ensures pro-features and general submission hooks are undisturbed.

---
*PR created automatically by Jules for task [8629948992382977131](https://jules.google.com/task/8629948992382977131) started by @mdjwel*