### PR TITLE
⚒️ Forge: Application Status Notifications

### DIFF
--- a/includes/Classes/Notification_Manager.php
+++ b/includes/Classes/Notification_Manager.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Notification Manager Class
+ *
+ * Handles sending emails and notifications for application events.
+ */
+class Notification_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Hook into application status change to send candidate notification
+		add_action( 'jobus_application_status_changed', [ $this, 'notify_candidate_status_change' ], 10, 3 );
+	}
+
+	/**
+	 * Send an email notification to the candidate when their application status changes.
+	 *
+	 * @param int    $application_id The ID of the application post.
+	 * @param string $old_status     The old status of the application.
+	 * @param string $new_status     The new status of the application.
+	 */
+	public function notify_candidate_status_change( $application_id, $old_status, $new_status ) {
+		// Check if application status emails are enabled via filter
+		if ( ! apply_filters( 'jobus_enable_application_status_email', true ) ) {
+			return;
+		}
+
+		// Ensure we actually have a status change
+		if ( $old_status === $new_status ) {
+			return;
+		}
+
+		$candidate_email = get_post_meta( $application_id, 'candidate_email', true );
+		if ( ! is_email( $candidate_email ) ) {
+			return;
+		}
+
+		$candidate_fname = get_post_meta( $application_id, 'candidate_fname', true );
+		$job_title       = get_post_meta( $application_id, 'job_applied_for_title', true );
+		if ( empty( $job_title ) ) {
+			$job_id = get_post_meta( $application_id, 'job_applied_for_id', true );
+			if ( $job_id ) {
+				$job_title = get_the_title( $job_id );
+			}
+		}
+
+		$site_name = get_bloginfo( 'name' );
+
+		// Format the email subject
+		$subject = sprintf( __( 'Application Update: %s - %s', 'jobus' ), $job_title, ucfirst( $new_status ) );
+
+		// Format the email body based on the new status
+		$message  = sprintf( __( 'Hello %s,', 'jobus' ), $candidate_fname ) . "\n\n";
+		$message .= sprintf( __( 'There has been an update regarding your application for the position of "%s".', 'jobus' ), $job_title ) . "\n\n";
+		$message .= sprintf( __( 'Your application status has been changed to: %s.', 'jobus' ), ucfirst( $new_status ) ) . "\n\n";
+
+		if ( 'approved' === $new_status ) {
+			$message .= __( 'Congratulations! The employer is interested in your profile and may contact you soon for further steps.', 'jobus' ) . "\n\n";
+		} elseif ( 'rejected' === $new_status ) {
+			$message .= __( 'Unfortunately, the employer has decided not to move forward with your application at this time. We wish you the best in your job search.', 'jobus' ) . "\n\n";
+		}
+
+		$message .= sprintf( __( 'Best regards, %s', 'jobus' ), $site_name );
+
+		$headers = [ 'Content-Type: text/plain; charset=UTF-8' ];
+
+		wp_mail( $candidate_email, $subject, $message, $headers );
+	}
+}

--- a/includes/Frontend/Dashboard_Helper.php
+++ b/includes/Frontend/Dashboard_Helper.php
@@ -273,10 +273,26 @@ class Dashboard_Helper {
 			}
 		}
 
+		// Get old status to check for changes
+		$old_status = get_post_meta( $application_id, 'application_status', true );
+
 		// Update the application status
 		$updated = update_post_meta( $application_id, 'application_status', $new_status );
 
 		if ( $updated || get_post_meta( $application_id, 'application_status', true ) === $new_status ) {
+
+			// Fire hook if status has actually changed
+			if ( $old_status !== $new_status ) {
+				/**
+				 * Fires after an application's status is updated via employer dashboard.
+				 *
+				 * @param int    $application_id The ID of the application post.
+				 * @param string $old_status     The previous status of the application.
+				 * @param string $new_status     The new status of the application.
+				 */
+				do_action( 'jobus_application_status_changed', $application_id, $old_status, $new_status );
+			}
+
 			wp_send_json_success( [
 				'message' => __( 'Application status updated successfully.', 'jobus' ),
 				'status'  => $new_status,

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Notification_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {


### PR DESCRIPTION
💡 **What:** Added application status change notifications for candidates when employers update their status in the dashboard.
🎯 **Why:** Previously, candidates had to continually check the dashboard to see if they were approved or rejected. This manual check represents a workflow gap and frustration.
⏱️ **Time Saved:** Saves candidates significant anxiety and manual checking time, while saving employers from answering status inquiry emails.
🔧 **How:** Updated `update_application_status()` in `Dashboard_Helper.php` to verify status changes and fire a new action hook `jobus_application_status_changed`. Created `Notification_Manager.php` which listens to this hook and sends an email via `wp_mail`.
🔌 **Extensibility:** The new action hook can be used by Jobus Pro to send SMS/Push notifications. The email sending can be toggled off via the `jobus_enable_application_status_email` boolean filter.
✅ **Testing:** Tested via a standalone PHP script mocking WP core functions to ensure emails are correctly formed and only sent when the status actually changes. Verified syntax of all modified files.
🔄 **Compatibility:** Fully compatible with Jobus Pro as it uses standard WordPress hooks and relies entirely on existing data structures.

---
*PR created automatically by Jules for task [436446194451218788](https://jules.google.com/task/436446194451218788) started by @mdjwel*