### PR TITLE
⚒️ Forge: Prevent duplicate job applications

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,33 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Prevent duplicate applications
+		$prevent_duplicates = apply_filters( 'jobus_prevent_duplicate_applications', true );
+		if ( $prevent_duplicates && ! empty( $candidate_email ) && ! empty( $job_application_id ) ) {
+			$existing_applications = get_posts( [
+				'post_type'      => 'jobus_applicant',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'meta_query'     => [
+					'relation' => 'AND',
+					[
+						'key'   => 'candidate_email',
+						'value' => $candidate_email,
+					],
+					[
+						'key'   => 'job_applied_for_id',
+						'value' => $job_application_id,
+					],
+				],
+				'fields'         => 'ids',
+			] );
+
+			if ( ! empty( $existing_applications ) ) {
+				wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+				wp_die();
+			}
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
💡 **What:** Added a workflow enhancement that prevents the same candidate from applying to the same job multiple times via the AJAX form.
🎯 **Why:** Previously, the system lacked a uniqueness constraint on applications, allowing a user to repeatedly submit the application form for the same job, creating duplicate data pollution for employers and candidates.
⏱️ **Time Saved:** Saves employers and candidates from dealing with duplicate noise and manual data cleanup. 
🔧 **How:** Hooked into `includes/Classes/Ajax_Actions.php::job_application_form` and added an efficient `get_posts` meta query (limit 1) check using `candidate_email` and `job_applied_for_id`. 
🔌 **Extensibility:** The duplicate check is wrapped in `apply_filters( 'jobus_prevent_duplicate_applications', true )` allowing site administrators to toggle it.
✅ **Testing:** Verified logic locally using standalone mock PHP scripts to confirm duplicates trigger a JSON error and valid new submissions proceed to `wp_insert_post`. Syntax verified via `php -l`.
🔄 **Compatibility:** No changes made to Jobus Pro hooks; safely integrated before post insertion.

---
*PR created automatically by Jules for task [9074551500106917726](https://jules.google.com/task/9074551500106917726) started by @mdjwel*