### PR TITLE
⚒️ Forge: Add Application Status Change Notifications

### DIFF
--- a/Admin/cpt/Job_Application.php
+++ b/Admin/cpt/Job_Application.php
@@ -79,7 +79,20 @@ class Job_Application {
 				wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['job_application_status_nonce'] ) ), 'job_application_status_action' ) ) {
 
 				$new_status = sanitize_text_field( wp_unslash( $_POST['application_status'] ) );
-				update_post_meta( $post->ID, 'application_status', $new_status );
+				$old_status = get_post_meta( $post->ID, 'application_status', true ) ?: 'pending';
+
+				$updated = update_post_meta( $post->ID, 'application_status', $new_status );
+				if ( $updated && $old_status !== $new_status ) {
+					/**
+					 * Fires after an application status is successfully updated.
+					 *
+					 * @since 1.0.0
+					 * @param int    $application_id The ID of the application post.
+					 * @param string $old_status     The previous status.
+					 * @param string $new_status     The new status.
+					 */
+					do_action( 'jobus_application_status_changed', $post->ID, $old_status, $new_status );
+				}
 			}
 
 			// Include the template file
@@ -101,8 +114,21 @@ class Job_Application {
 		
 		// Check if our custom status is set
 		if ( isset( $_POST['application_status'] ) ) {
-			$status = sanitize_text_field( wp_unslash( $_POST['application_status'] ) );
-			update_post_meta( $post_id, 'application_status', $status );
+			$status     = sanitize_text_field( wp_unslash( $_POST['application_status'] ) );
+			$old_status = get_post_meta( $post_id, 'application_status', true ) ?: 'pending';
+
+			$updated = update_post_meta( $post_id, 'application_status', $status );
+			if ( $updated && $old_status !== $status ) {
+				/**
+				 * Fires after an application status is successfully updated.
+				 *
+				 * @since 1.0.0
+				 * @param int    $application_id The ID of the application post.
+				 * @param string $old_status     The previous status.
+				 * @param string $new_status     The new status.
+				 */
+				do_action( 'jobus_application_status_changed', $post_id, $old_status, $status );
+			}
 		}
 	}
 

--- a/articles/forge-journal.md
+++ b/articles/forge-journal.md
@@ -1,0 +1,3 @@
+## 2026-02-07 - Application Status Change Notifications
+**Learning:** The `jobus_application_status_changed` action provides a critical integration point for Pro notifications, filling the highest-impact communication gap for candidates.
+**Action:** When implementing status updates, always fire `jobus_application_status_changed` even if the free version doesn't handle full templating, so extensions can hook in.

--- a/includes/Classes/Notification_Manager.php
+++ b/includes/Classes/Notification_Manager.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return; // Exit if accessed directly
+}
+
+/**
+ * Class Notification_Manager
+ *
+ * Handles email notifications for the Jobus plugin.
+ */
+class Notification_Manager {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Hook into application status change to send candidate notification
+		add_action( 'jobus_application_status_changed', [ $this, 'notify_candidate_on_status_change' ], 10, 3 );
+	}
+
+	/**
+	 * Send an email to the candidate when their application status changes.
+	 *
+	 * @param int    $application_id The ID of the application post.
+	 * @param string $old_status     The previous status.
+	 * @param string $new_status     The new status.
+	 */
+	public function notify_candidate_on_status_change( $application_id, $old_status, $new_status ) {
+		// Check if the feature is enabled via filter (can be toggled in settings or by Pro)
+		if ( ! apply_filters( 'jobus_enable_application_status_email', true ) ) {
+			return;
+		}
+
+		if ( $old_status === $new_status ) {
+			return; // No change
+		}
+
+		$candidate_email = get_post_meta( $application_id, 'candidate_email', true );
+		if ( ! is_email( $candidate_email ) ) {
+			return;
+		}
+
+		$candidate_name = get_post_meta( $application_id, 'candidate_fname', true ) . ' ' . get_post_meta( $application_id, 'candidate_lname', true );
+		$job_title      = get_post_meta( $application_id, 'job_applied_for_title', true );
+		$site_name      = get_bloginfo( 'name' );
+
+		// Map status slugs to readable labels
+		$status_labels = apply_filters( 'jobus_application_statuses', [
+			'pending'  => __( 'Pending', 'jobus' ),
+			'approved' => __( 'Approved', 'jobus' ),
+			'rejected' => __( 'Rejected', 'jobus' ),
+		] );
+
+		$readable_status = isset( $status_labels[ $new_status ] ) ? $status_labels[ $new_status ] : ucfirst( $new_status );
+
+		$subject = sprintf(
+			/* translators: 1: Job title, 2: New status */
+			__( 'Your application for "%1$s" is now %2$s', 'jobus' ),
+			$job_title,
+			$readable_status
+		);
+
+		$message = sprintf(
+			/* translators: 1: Candidate name, 2: Job title, 3: New status, 4: Site name */
+			__( "Hi %1\$s,\n\nThis is a notification to let you know that the status of your application for the position of \"%2\$s\" has been updated.\n\nYour application status is now: %3\$s.\n\nThank you,\n%4\$s", 'jobus' ),
+			trim( $candidate_name ) ?: __( 'Candidate', 'jobus' ),
+			$job_title,
+			$readable_status,
+			$site_name
+		);
+
+		$headers = [ 'Content-Type: text/plain; charset=UTF-8' ];
+
+		// Send the email
+		wp_mail( $candidate_email, $subject, $message, $headers );
+	}
+}

--- a/includes/Frontend/Dashboard_Helper.php
+++ b/includes/Frontend/Dashboard_Helper.php
@@ -273,10 +273,24 @@ class Dashboard_Helper {
 			}
 		}
 
+		$old_status = get_post_meta( $application_id, 'application_status', true ) ?: 'pending';
+
 		// Update the application status
 		$updated = update_post_meta( $application_id, 'application_status', $new_status );
 
-		if ( $updated || get_post_meta( $application_id, 'application_status', true ) === $new_status ) {
+		if ( $updated || $old_status === $new_status ) {
+			if ( $updated && $old_status !== $new_status ) {
+				/**
+				 * Fires after an application status is successfully updated.
+				 *
+				 * @since 1.0.0
+				 * @param int    $application_id The ID of the application post.
+				 * @param string $old_status     The previous status.
+				 * @param string $new_status     The new status.
+				 */
+				do_action( 'jobus_application_status_changed', $application_id, $old_status, $new_status );
+			}
+
 			wp_send_json_success( [
 				'message' => __( 'Application status updated successfully.', 'jobus' ),
 				'status'  => $new_status,

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Notification_Manager();
 
 		// Submission Classes
 		if ( $enable_candidate ) {


### PR DESCRIPTION
This PR introduces email notifications for candidates when their application status is updated (e.g., from Pending to Approved or Rejected).

- Adds the `jobus_application_status_changed` hook to both the Admin backend (`Admin/cpt/Job_Application.php`) and the employer frontend dashboard AJAX handler (`Dashboard_Helper.php`).
- Introduces `jobus\includes\Classes\Notification_Manager` to listen to this hook and send the email to the candidate.
- Integrates `Notification_Manager` into plugin initialization in `jobus.php`.
- Adds a filter `jobus_enable_application_status_email` to allow site admins or Pro versions to disable this built-in notification if needed.

Resolves a key missing workflow automation gap, significantly improving candidate experience.

---
*PR created automatically by Jules for task [17355884421124946121](https://jules.google.com/task/17355884421124946121) started by @mdjwel*