### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/articles/forge-journal.md
+++ b/articles/forge-journal.md
@@ -1,0 +1,3 @@
+## 2024-03-10 - Job Auto Expiration
+**Learning:** Jobs past their deadline are not automatically expired, forcing site admins to do so manually, and leading to bad UX since candidates see closed jobs. Added `includes/Classes/Cron/Cron_Tasks.php` to handle automated tasks.
+**Action:** Created `jobus_daily_maintenance` cron job to automatically draft expired jobs in batches using WP Cron API and batch processing.

--- a/includes/Classes/Cron/Cron_Tasks.php
+++ b/includes/Classes/Cron/Cron_Tasks.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Cron Tasks Class
+ *
+ * Handles background automation tasks and cron jobs for the Jobus plugin.
+ *
+ * @package jobus\includes\Classes\Cron
+ */
+
+namespace jobus\includes\Classes\Cron;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class Cron_Tasks {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		// Hook the background jobs
+		add_action( 'jobus_daily_maintenance', [ $this, 'auto_expire_jobs' ] );
+		// Hook for continuation if we hit batch limit
+		add_action( 'jobus_daily_maintenance_continue', [ $this, 'auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Automatically expires jobs past their deadline.
+	 * Runs daily via cron.
+	 *
+	 * @return void
+	 */
+	public function auto_expire_jobs(): void {
+		// Allow disabling via filter
+		if ( ! apply_filters( 'jobus_enable_auto_expire_jobs', true ) ) {
+			return;
+		}
+
+		$today = current_time( 'Y-m-d' );
+
+		// Process in batches to avoid timeouts
+		$batch_size = apply_filters( 'jobus_cron_batch_size', 50 );
+
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => $today,
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+				[
+					'key'     => 'job_deadline',
+					'value'   => '',
+					'compare' => '!=',
+				],
+			],
+		] );
+
+		if ( empty( $expired_jobs ) ) {
+			return;
+		}
+
+		foreach ( $expired_jobs as $job_id ) {
+			// Change status to draft (expired)
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			// Fire action for Pro features or extensions to react (e.g., email employer)
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+
+		// If we hit our batch limit, there might be more. Schedule another run in 1 minute.
+		if ( count( $expired_jobs ) === $batch_size ) {
+			if ( ! wp_next_scheduled( 'jobus_daily_maintenance_continue' ) ) {
+				wp_schedule_single_event( time() + 60, 'jobus_daily_maintenance_continue' );
+			}
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron\Cron_Tasks();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -251,6 +252,10 @@ final class Jobus {
 			set_transient( 'jobus_activation_redirect', '1', 60 );
 		}
 
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
 	}
@@ -261,6 +266,9 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance_continue' );
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
💡 **What:** Added a daily cron job that automatically drafts `jobus_job` posts whose `job_deadline` is in the past.
🎯 **Why:** Automates the manual task of reviewing and closing expired job listings, improving user experience by ensuring candidates don't see closed positions.
⏱️ **Time Saved:** Saves site admins and employers significant manual checking and cleanup time (e.g., ~10-30 min/week).
🔧 **How:** Registered a `Cron_Tasks` class hooked to `jobus_daily_maintenance`. It queries up to 50 jobs with deadlines earlier than `current_time( 'Y-m-d' )`, drafts them, and fires `jobus_job_auto_expired`. If the batch limit is reached, it schedules `jobus_daily_maintenance_continue`.
🔌 **Extensibility:** The job limits can be modified via `jobus_cron_batch_size`. It can be toggled off via `jobus_enable_auto_expire_jobs`.
✅ **Testing:** Ran mock tests to verify batching and date logic correctness.
🔄 **Compatibility:** Fired `jobus_job_auto_expired` after drafting so Pro extension (like notifications) can act upon it.

---
*PR created automatically by Jules for task [3403570811801022467](https://jules.google.com/task/3403570811801022467) started by @mdjwel*