### PR TITLE
⚒️ Forge: Add Application Status Change Notifications

### DIFF
--- a/includes/Classes/Notifications.php
+++ b/includes/Classes/Notifications.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Notifications Class
+ *
+ * Handles automated email notifications for the Jobus plugin.
+ */
+class Notifications {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_application_status_changed', [ $this, 'notify_candidate_on_status_change' ], 10, 3 );
+	}
+
+	/**
+	 * Send an email notification to the candidate when their application status changes.
+	 *
+	 * @param int    $application_id Application post ID.
+	 * @param string $old_status     The previous status.
+	 * @param string $new_status     The new status.
+	 *
+	 * @return void
+	 */
+	public function notify_candidate_on_status_change( $application_id, $old_status, $new_status ): void {
+		// Allow site administrators to disable this notification
+		if ( ! apply_filters( 'jobus_enable_application_status_email', true ) ) {
+			return;
+		}
+
+		if ( $old_status === $new_status ) {
+			return; // Early return - no change
+		}
+
+		$candidate_email = get_post_meta( $application_id, 'applicant_email', true );
+		if ( empty( $candidate_email ) || ! is_email( $candidate_email ) ) {
+			return;
+		}
+
+		$job_id    = get_post_meta( $application_id, 'job_id', true );
+		$job_title = $job_id ? get_the_title( $job_id ) : get_post_meta( $application_id, 'job_applied_for_title', true );
+
+		if ( empty( $job_title ) ) {
+			$job_title = __( 'a job', 'jobus' );
+		}
+
+		// Prepare email content based on status
+		switch ( $new_status ) {
+			case 'approved':
+				/* translators: %s: Job title */
+				$subject = sprintf( __( 'Application Approved: %s', 'jobus' ), $job_title );
+				/* translators: 1: Job title */
+				$message = sprintf( __( 'Good news! Your application for "%1$s" has been approved by the employer.', 'jobus' ), $job_title );
+				break;
+
+			case 'rejected':
+				/* translators: %s: Job title */
+				$subject = sprintf( __( 'Application Update: %s', 'jobus' ), $job_title );
+				/* translators: 1: Job title */
+				$message = sprintf( __( 'Thank you for your interest. Unfortunately, your application for "%1$s" has been rejected at this time.', 'jobus' ), $job_title );
+				break;
+
+			case 'pending':
+			default:
+				/* translators: %s: Job title */
+				$subject = sprintf( __( 'Application Status Updated: %s', 'jobus' ), $job_title );
+				/* translators: 1: Job title, 2: New status */
+				$message = sprintf( __( 'Your application for "%1$s" is now marked as %2$s.', 'jobus' ), $job_title, $new_status );
+				break;
+		}
+
+		// Allow filtering the email subject and message
+		$subject = apply_filters( 'jobus_application_status_email_subject', $subject, $application_id, $new_status, $job_title );
+		$message = apply_filters( 'jobus_application_status_email_message', $message, $application_id, $new_status, $job_title );
+
+		// Set content type to HTML if desired, but default to plain text for simplicity and compatibility
+		$headers = [ 'Content-Type: text/plain; charset=UTF-8' ];
+
+		wp_mail( $candidate_email, $subject, $message, $headers );
+	}
+}

--- a/includes/Frontend/Dashboard_Helper.php
+++ b/includes/Frontend/Dashboard_Helper.php
@@ -273,10 +273,24 @@ class Dashboard_Helper {
 			}
 		}
 
+		// Get old status
+		$old_status = get_post_meta( $application_id, 'application_status', true );
+
 		// Update the application status
 		$updated = update_post_meta( $application_id, 'application_status', $new_status );
 
-		if ( $updated || get_post_meta( $application_id, 'application_status', true ) === $new_status ) {
+		if ( $updated || $old_status === $new_status ) {
+			if ( $old_status !== $new_status ) {
+				/**
+				 * Fires when an application status is changed.
+				 *
+				 * @param int    $application_id Application ID.
+				 * @param string $old_status     Old status.
+				 * @param string $new_status     New status.
+				 */
+				do_action( 'jobus_application_status_changed', $application_id, $old_status, $new_status );
+			}
+
 			wp_send_json_success( [
 				'message' => __( 'Application status updated successfully.', 'jobus' ),
 				'status'  => $new_status,

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Notifications();
 
 		// Submission Classes
 		if ( $enable_candidate ) {


### PR DESCRIPTION
💡 **What:** Added an automated email notification that triggers when an application status changes (e.g., from pending to approved or rejected).
🎯 **Why:** Candidates currently have to repeatedly check their dashboard to see if their application was reviewed. This automation pushes the update directly to their inbox, saving them time and reducing anxiety.
⏱️ **Time Saved:** Saves candidates multiple logins and checks per application.
🔧 **How:** Hooked into `update_application_status` in `Dashboard_Helper.php` to fire a new `jobus_application_status_changed` action. Created a new `Notifications.php` class to listen to this hook and send the email.
🔌 **Extensibility:** Added `jobus_application_status_changed` action, `jobus_enable_application_status_email` filter to disable the email, and `jobus_application_status_email_subject` / `jobus_application_status_email_message` filters to customize content.
✅ **Testing:** Verified old vs new status comparison and email content generation logic via standalone PHP script, ensuring no emails are sent if status doesn't change.
🔄 **Compatibility:** Fully compliant with WP Coding Standards and easily extensible for Jobus Pro features.

---
*PR created automatically by Jules for task [6310934067316624380](https://jules.google.com/task/6310934067316624380) started by @mdjwel*