### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/includes/Classes/Cron.php
+++ b/includes/Classes/Cron.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Cron Class for Jobus Plugin
+ *
+ * Handles scheduled tasks and automated workflows.
+ *
+ * @package Jobus\includes\Classes
+ * @since   1.6.0
+ */
+
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Cron
+ *
+ * Manages WordPress cron jobs for automation tasks.
+ */
+class Cron {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Hook into the main daily maintenance cron event
+		add_action( 'jobus_daily_maintenance', [ $this, 'auto_expire_jobs' ] );
+
+		// Hook into the continuation event for batch processing
+		add_action( 'jobus_daily_maintenance_continue', [ $this, 'auto_expire_jobs_batch_continue' ] );
+	}
+
+	/**
+	 * Automatically expire jobs past their deadline.
+	 *
+	 * This method is called by the daily cron and initiates the first batch.
+	 *
+	 * @return void
+	 */
+	public function auto_expire_jobs(): void {
+		// Respect user control - allow disabling this automation
+		if ( ! apply_filters( 'jobus_enable_auto_expire_jobs', true ) ) {
+			return;
+		}
+
+		$this->process_expired_jobs_batch();
+	}
+
+	/**
+	 * Process a continuation batch of expired jobs.
+	 *
+	 * This method is called by the continuation cron when there are more jobs to process.
+	 *
+	 * @return void
+	 */
+	public function auto_expire_jobs_batch_continue(): void {
+		// Respect user control
+		if ( ! apply_filters( 'jobus_enable_auto_expire_jobs', true ) ) {
+			return;
+		}
+
+		$this->process_expired_jobs_batch();
+	}
+
+	/**
+	 * Process a batch of jobs that have passed their deadline.
+	 *
+	 * Queries for published jobs with a deadline in the past, updates their
+	 * status to draft, and fires an action hook for extensibility.
+	 *
+	 * @return void
+	 */
+	private function process_expired_jobs_batch(): void {
+		// Use a configurable batch size to prevent timeouts
+		$batch_size = (int) apply_filters( 'jobus_cron_batch_size', 50 );
+		$today      = current_time( 'Y-m-d' );
+
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => $today,
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+				[
+					'key'     => 'job_deadline',
+					'value'   => '',
+					'compare' => '!=',
+				],
+			],
+		] );
+
+		if ( empty( $expired_jobs ) ) {
+			return;
+		}
+
+		foreach ( $expired_jobs as $job_id ) {
+			// Update the post status to draft
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			/**
+			 * Fires after a job has been automatically expired by the cron job.
+			 *
+			 * @since 1.6.0
+			 * @param int $job_id The ID of the expired job post.
+			 */
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+
+		// If we fetched the maximum batch size, there might be more jobs.
+		// Schedule a continuation event to process the next batch.
+		if ( count( $expired_jobs ) === $batch_size ) {
+			wp_schedule_single_event( time() + 60, 'jobus_daily_maintenance_continue' );
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -251,6 +252,11 @@ final class Jobus {
 			set_transient( 'jobus_activation_redirect', '1', 60 );
 		}
 
+		// Schedule daily maintenance cron job
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
 	}
@@ -261,6 +267,10 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		// Clear scheduled cron events
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance_continue' );
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
⚒️ Forge: Auto-expire jobs past deadline via daily cron

This implements the highest-priority automation to save manual effort for site administrators and employers.

💡 What: A new `Cron` class that automatically drafts published jobs when their `job_deadline` has passed.
🎯 Why: Prevents manual administrative overhead. Administrators previously had to manually search and close expired listings to prevent candidates from applying to outdated roles.
⏱️ Time Saved: Saves administrators and employers significant time per week by automating the cleanup of expired jobs.
🔧 How: Hooked into a new `jobus_daily_maintenance` WP cron event. Queries for expired jobs in configurable batches (default 50) and schedules a continuation event (`jobus_daily_maintenance_continue`) if the batch limit is hit to prevent PHP timeouts on large sites.
🔌 Extensibility: Added `apply_filters('jobus_enable_auto_expire_jobs', true)` as an off-switch, and `do_action('jobus_job_auto_expired', $job_id)` so Pro extensions can trigger email notifications to employers.
✅ Testing: Verified via a standalone test script that mocked the environment to ensure the batching limit correctly schedules continuation events. No memory or execution timeout issues.
🔄 Compatibility: Safe to run with or without Jobus Pro. Uses native `get_posts` and `wp_update_post` for maximum compatibility.

---
*PR created automatically by Jules for task [10308174577630215788](https://jules.google.com/task/10308174577630215788) started by @mdjwel*