### PR TITLE
⚒️ Forge: Application status change notifications

### DIFF
--- a/Admin/cpt/Job_Application.php
+++ b/Admin/cpt/Job_Application.php
@@ -79,7 +79,12 @@ class Job_Application {
 				wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['job_application_status_nonce'] ) ), 'job_application_status_action' ) ) {
 
 				$new_status = sanitize_text_field( wp_unslash( $_POST['application_status'] ) );
-				update_post_meta( $post->ID, 'application_status', $new_status );
+				$old_status = get_post_meta( $post->ID, 'application_status', true ) ?: 'pending';
+				$updated    = update_post_meta( $post->ID, 'application_status', $new_status );
+
+				if ( $old_status !== $new_status ) {
+					do_action( 'jobus_application_status_changed', $post->ID, $old_status, $new_status );
+				}
 			}
 
 			// Include the template file
@@ -101,8 +106,16 @@ class Job_Application {
 		
 		// Check if our custom status is set
 		if ( isset( $_POST['application_status'] ) ) {
-			$status = sanitize_text_field( wp_unslash( $_POST['application_status'] ) );
-			update_post_meta( $post_id, 'application_status', $status );
+			$new_status = sanitize_text_field( wp_unslash( $_POST['application_status'] ) );
+			$old_status = get_post_meta( $post_id, 'application_status', true ) ?: 'pending';
+
+			// update_post_meta returns true if successful or false if nothing changed,
+			// but we can just update it then check if it changed to fire action.
+			$updated = update_post_meta( $post_id, 'application_status', $new_status );
+
+			if ( $old_status !== $new_status ) {
+				do_action( 'jobus_application_status_changed', $post_id, $old_status, $new_status );
+			}
 		}
 	}
 

--- a/includes/Classes/Notifications.php
+++ b/includes/Classes/Notifications.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Use namespace to avoid conflict
+ */
+namespace jobus\includes\Classes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Notifications Class
+ *
+ * Handles automated email notifications for the Jobus plugin.
+ */
+class Notifications {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Hook into application status changes to notify candidate
+		add_action( 'jobus_application_status_changed', [ $this, 'notify_candidate_on_status_change' ], 10, 3 );
+	}
+
+	/**
+	 * Send an email to the candidate when their application status changes.
+	 *
+	 * @param int    $application_id The application ID.
+	 * @param string $old_status     The old status.
+	 * @param string $new_status     The new status.
+	 *
+	 * @return void
+	 */
+	public function notify_candidate_on_status_change( $application_id, $old_status, $new_status ): void {
+		// Only send email for meaningful status changes
+		if ( $old_status === $new_status || 'pending' === $new_status ) {
+			return;
+		}
+
+		// Check if notification is enabled via filter
+		if ( ! apply_filters( 'jobus_enable_application_status_email', true ) ) {
+			return;
+		}
+
+		$candidate_email = get_post_meta( $application_id, 'candidate_email', true );
+		if ( ! is_email( $candidate_email ) ) {
+			// Fallback to applicant_email if candidate_email is not found
+			$candidate_email = get_post_meta( $application_id, 'applicant_email', true );
+		}
+		if ( ! is_email( $candidate_email ) ) {
+			return;
+		}
+
+		$job_title = get_post_meta( $application_id, 'job_applied_for_title', true );
+		if ( ! $job_title ) {
+			$job_id = get_post_meta( $application_id, 'job_applied_for_id', true );
+			if ( ! $job_id ) {
+				$job_id = get_post_meta( $application_id, 'job_id', true );
+			}
+			if ( $job_id ) {
+				$job_title = get_the_title( $job_id );
+			}
+		}
+
+		$job_title_display = $job_title ? $job_title : __( 'a job', 'jobus' );
+
+		$subject = sprintf( __( 'Update on your application for: %1$s', 'jobus' ), $job_title_display );
+
+		$message  = sprintf( __( 'Hello,', 'jobus' ) ) . "\n\n";
+		$message .= sprintf( __( 'There has been an update regarding your application for the position of "%1$s".', 'jobus' ), $job_title_display ) . "\n\n";
+
+		if ( 'approved' === $new_status ) {
+			$message .= __( 'Good news! Your application has been approved. The employer will likely contact you soon with next steps.', 'jobus' ) . "\n\n";
+		} elseif ( 'rejected' === $new_status ) {
+			$message .= __( 'We regret to inform you that your application was not successful this time. Thank you for your interest.', 'jobus' ) . "\n\n";
+		} else {
+			$message .= sprintf( __( 'Your application status has been changed to: %1$s.', 'jobus' ), ucfirst( $new_status ) ) . "\n\n";
+		}
+
+		$message .= __( 'Best regards,', 'jobus' ) . "\n";
+		$message .= get_bloginfo( 'name' );
+
+		// Send email
+		wp_mail( $candidate_email, $subject, $message );
+	}
+}

--- a/includes/Frontend/Dashboard_Helper.php
+++ b/includes/Frontend/Dashboard_Helper.php
@@ -274,9 +274,23 @@ class Dashboard_Helper {
 		}
 
 		// Update the application status
-		$updated = update_post_meta( $application_id, 'application_status', $new_status );
+		$old_status = get_post_meta( $application_id, 'application_status', true ) ?: 'pending';
+		$updated    = update_post_meta( $application_id, 'application_status', $new_status );
 
 		if ( $updated || get_post_meta( $application_id, 'application_status', true ) === $new_status ) {
+			if ( $old_status !== $new_status ) {
+				/**
+				 * Fires when a job application status is changed.
+				 *
+				 * @since 1.0.0
+				 *
+				 * @param int    $application_id The ID of the application post.
+				 * @param string $old_status     The previous status.
+				 * @param string $new_status     The new status.
+				 */
+				do_action( 'jobus_application_status_changed', $application_id, $old_status, $new_status );
+			}
+
 			wp_send_json_success( [
 				'message' => __( 'Application status updated successfully.', 'jobus' ),
 				'status'  => $new_status,

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Notifications();
 
 		// Submission Classes
 		if ( $enable_candidate ) {


### PR DESCRIPTION
💡 **What:** Implemented automated email notifications to candidates when their job application status changes. Added a new hook `jobus_application_status_changed` and a `Notifications` class to handle email dispatch.
🎯 **Why:** Candidates currently have to manually log in repeatedly to check their application status. This automation eliminates that friction by proactively notifying them when an employer updates their status (e.g., to "approved" or "rejected").
⏱️ **Time Saved:** Saves candidates significant time by pushing updates to them directly, and saves employers from answering "what's my status" inquiries.
🔧 **How:** 
- Hooked into `Admin/cpt/Job_Application.php` and `includes/Frontend/Dashboard_Helper.php` to detect actual status changes and fire `jobus_application_status_changed`.
- Created `Notifications` class hooked to this event to fetch candidate details and dispatch an email using `wp_mail`.
🔌 **Extensibility:** The `jobus_application_status_changed` hook can be used by Pro addons. The email dispatch can be toggled via the `jobus_enable_application_status_email` filter.
✅ **Testing:** Created a standalone mock WP script to verify hook triggering, candidate email extraction (handling `candidate_email` and `applicant_email` fallbacks), and correct formatting of approval/rejection emails.
🔄 **Compatibility:** Follows existing patterns and provides robust fallbacks for meta keys to ensure compatibility with various data structures.

---
*PR created automatically by Jules for task [401789285229664562](https://jules.google.com/task/401789285229664562) started by @mdjwel*