### PR TITLE
⚒️ Forge: Prevent duplicate job applications

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,33 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Check for duplicate application
+		if ( apply_filters( 'jobus_enable_duplicate_application_check', true ) ) {
+			$existing_application = get_posts( [
+				'post_type'      => 'jobus_applicant',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'meta_query'     => [
+					'relation' => 'AND',
+					[
+						'key'     => 'candidate_email',
+						'value'   => $candidate_email,
+						'compare' => '=',
+					],
+					[
+						'key'     => 'job_applied_for_id',
+						'value'   => $job_application_id,
+						'compare' => '=',
+					],
+				],
+			] );
+
+			if ( ! empty( $existing_application ) ) {
+				wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+			}
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
💡 **What:** Added logic to prevent candidates from submitting duplicate applications for the same job.
🎯 **Why:** To eliminate manual effort and noise for employers by blocking redundant submissions, reducing "wasted time" evaluating duplicate data.
⏱️ **Time Saved:** Saves employers time filtering through identical applications in their dashboard and minimizes false analytics.
🔧 **How:** Before `wp_insert_post` is called in the `job_application_form` AJAX handler, a highly constrained query (`get_posts` with `fields => ids` and `posts_per_page => 1`) checks if an application exists with the matching email and job ID.
🔌 **Extensibility:** The check is wrapped in the `jobus_enable_duplicate_application_check` filter, allowing site admins to disable the automation via code if needed.
✅ **Testing:** Verified via isolated PHP script mocking WP functions that the duplicate check prevents submission and returns the error message, while valid new applications succeed.
🔄 **Compatibility:** Fully compatible with Jobus Pro features; simply intercepts the form process early.

---
*PR created automatically by Jules for task [9745483227962637379](https://jules.google.com/task/9745483227962637379) started by @mdjwel*