### PR TITLE
⚒️ Forge: Prevent duplicate job applications

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,32 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Prevent duplicate applications
+		if ( apply_filters( 'jobus_enable_duplicate_application_check', true ) ) {
+			$existing_application = get_posts( [
+				'post_type'      => 'jobus_applicant',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'meta_query'     => [
+					'relation' => 'AND',
+					[
+						'key'   => 'candidate_email',
+						'value' => $candidate_email,
+					],
+					[
+						'key'   => 'job_applied_for_id',
+						'value' => $job_application_id,
+					],
+				],
+			] );
+
+			if ( ! empty( $existing_application ) ) {
+				wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+				wp_die();
+			}
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
💡 **What:** The workflow automation or enhancement implemented is a check that prevents the same candidate email from submitting multiple applications to the same job listing.
🎯 **Why:** Candidates were able to click submit multiple times or re-apply continuously, creating duplicate records that employers had to manually identify and remove.
⏱️ **Time Saved:** Saves employers time reviewing applications by ensuring every submission in their dashboard represents a unique applicant per job.
🔧 **How:** Implementation approach involved updating the `job_application_form` AJAX handler in `includes/Classes/Ajax_Actions.php` to perform a highly optimized `get_posts` query before `wp_insert_post`, checking if an application already exists.
🔌 **Extensibility:** Added a new boolean filter `jobus_enable_duplicate_application_check` allowing Pro or administrators to programmatically toggle this strict requirement.
✅ **Testing:** Tested using an isolated mock WordPress environment to ensure duplicate cases return the proper translated error message and unique cases proceed without issue.
🔄 **Compatibility:** Confirmed to safely hook into the existing application creation flow without side effects.

---
*PR created automatically by Jules for task [2948503836810518675](https://jules.google.com/task/2948503836810518675) started by @mdjwel*