### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/articles/forge-journal.md
+++ b/articles/forge-journal.md
@@ -1,0 +1,3 @@
+## 2026-02-07 - Auto-expire jobs via Cron
+**Learning:** When using batched processing in a scheduled WordPress cron to avoid timeouts, always hook the continuation batch to a separate hook (e.g. `jobus_auto_expire_jobs_batch_continue`) or register the handler directly to it rather than re-scheduling the daily hook (`jobus_daily_maintenance`) to avoid overlapping schedules.
+**Action:** Implemented `wp_schedule_single_event` for batch continuation linking to the same class handler in `Job_Expirator.php`.

--- a/includes/Classes/Cron/Job_Expirator.php
+++ b/includes/Classes/Cron/Job_Expirator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace jobus\includes\Classes\Cron;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die; // Exit if accessed directly.
+}
+
+/**
+ * Class Job_Expirator
+ *
+ * Handles auto-expiration of jobs when their deadline is reached.
+ */
+class Job_Expirator {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'auto_expire_jobs' ] );
+		add_action( 'jobus_auto_expire_jobs_batch_continue', [ $this, 'auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Automatically expires jobs whose deadline has passed.
+	 *
+	 * Changes their status to 'draft' and fires an action hook.
+	 * Processes in batches to avoid timeouts.
+	 */
+	public function auto_expire_jobs(): void {
+		// Respect the disable filter/toggle
+		if ( ! apply_filters( 'jobus_enable_auto_expire_jobs', true ) ) {
+			return;
+		}
+
+		$batch_size = apply_filters( 'jobus_cron_batch_size', 50 );
+
+		// Query for jobs that have past their deadline and are still published
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => current_time( 'Y-m-d' ),
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+			],
+		] );
+
+		if ( empty( $expired_jobs ) ) {
+			return;
+		}
+
+		foreach ( $expired_jobs as $job_id ) {
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			/**
+			 * Fires when a job is auto-expired by the cron.
+			 *
+			 * @param int $job_id The ID of the expired job.
+			 */
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+
+		// If we processed a full batch, schedule another run immediately to process the rest
+		if ( count( $expired_jobs ) === $batch_size ) {
+			// Schedule continuation batch, not the daily one to avoid overlapping scheduling
+			wp_schedule_single_event( time() + 60, 'jobus_auto_expire_jobs_batch_continue' );
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron\Job_Expirator();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -251,6 +252,10 @@ final class Jobus {
 			set_transient( 'jobus_activation_redirect', '1', 60 );
 		}
 
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
 	}
@@ -261,6 +266,9 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+		wp_clear_scheduled_hook( 'jobus_auto_expire_jobs_batch_continue' );
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
💡 **What:** Implemented a daily WP-Cron event (`jobus_daily_maintenance`) that automatically transitions jobs to `draft` status if their `job_deadline` has passed.

🎯 **Why:** Admins and employers previously had to manually find and close expired job listings. This creates manual busywork and risks expired jobs remaining visible to candidates.

⏱️ **Time Saved:** Saves admins/employers significant time depending on listing volume, entirely automating the expiration cleanup.

🔧 **How:**
- Created `jobus\includes\Classes\Cron\Job_Expirator`.
- Fetches published jobs in batches (configurable via `jobus_cron_batch_size`, default 50).
- Compares `job_deadline` meta against `current_time('Y-m-d')`.
- Schedules a single event continuation (`jobus_auto_expire_jobs_batch_continue`) if a full batch is processed, avoiding PHP timeouts on large datasets.
- Hooked setup and cleanup on plugin activation/deactivation in `jobus.php`.

🔌 **Extensibility:**
- Filter `jobus_enable_auto_expire_jobs` allows disabling the automation.
- Action `jobus_job_auto_expired` fires when a job is expired, allowing Pro features (like email notifications) to react.
- Filter `jobus_cron_batch_size` controls the processing chunk size.

✅ **Testing:**
- Verified WP scheduling and un-scheduling logic.
- Simulated batched processing using a standalone PHP script mimicking WP functions.
- Verified correct `get_posts` parameters and status updates.
- Checked syntax and WordPress coding standard guidelines for automation.

🔄 **Compatibility:** Confirmed to safely trigger without breaking any Pro hooks, and provides necessary actions for Pro modules.

---
*PR created automatically by Jules for task [1709659490594766516](https://jules.google.com/task/1709659490594766516) started by @mdjwel*