### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/includes/Classes/Cron/Job_Expirator.php
+++ b/includes/Classes/Cron/Job_Expirator.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Use namespace to avoid conflict
+ */
+
+namespace jobus\includes\Classes\Cron;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Job Expirator Class
+ *
+ * Handles auto-expiring jobs past their deadline.
+ */
+class Job_Expirator {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'auto_expire_jobs' ] );
+		add_action( 'jobus_auto_expire_jobs_batch_continue', [ $this, 'auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Auto expire jobs past their deadline.
+	 *
+	 * @return void
+	 */
+	public function auto_expire_jobs(): void {
+		// Allow site administrators to programmatically disable auto-expire
+		if ( ! apply_filters( 'jobus_enable_auto_expire_jobs', true ) ) {
+			return;
+		}
+
+		$batch_size = apply_filters( 'jobus_auto_expire_jobs_batch_size', 50 );
+		$today      = current_time( 'Y-m-d' );
+
+		$args = [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => $today,
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+			],
+		];
+
+		$expired_jobs = get_posts( $args );
+
+		if ( empty( $expired_jobs ) ) {
+			return;
+		}
+
+		foreach ( $expired_jobs as $job_id ) {
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			/**
+			 * Fires after a job has been auto-expired.
+			 *
+			 * @since 1.7.0
+			 * @param int $job_id The ID of the expired job.
+			 */
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+
+		// If the batch is full, schedule another run to continue processing
+		if ( count( $expired_jobs ) === $batch_size ) {
+			wp_schedule_single_event( time() + 60, 'jobus_auto_expire_jobs_batch_continue' );
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron\Job_Expirator();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -253,6 +254,11 @@ final class Jobus {
 			set_transient( 'jobus_activation_redirect', '1', 60 );
 		}
 
+		// Register daily maintenance cron if not scheduled
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
+
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
 	}
@@ -263,6 +269,10 @@ final class Jobus {
 	 * @return void
 	 */
 	public function deactivate(): void {
+		// Clear scheduled cron hooks
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+		wp_clear_scheduled_hook( 'jobus_auto_expire_jobs_batch_continue' );
+
 		// If premium is NOT active, we might want to clean up.
 		// However, per user request, we remove the dashboard page if Jobus-pro is not active.
 		if ( ! function_exists( 'jobus_is_premium' ) || ! jobus_is_premium() ) {


### PR DESCRIPTION
💡 **What:** Implemented a daily cron job that automatically changes the status of expired job listings (where `job_deadline` < today) from 'publish' to 'draft'.
🎯 **Why:** Previously, admins/employers had to manually find and close expired listings, leaving stale jobs visible in search results and cluttering dashboards.
⏱️ **Time Saved:** Saves admins and employers hours per month by automatically removing obsolete job posts from the active pool.
🔧 **How:** 
  - Created a new class `jobus\includes\Classes\Cron\Job_Expirator`.
  - Registered a daily event `jobus_daily_maintenance` upon plugin activation and cleared it upon deactivation.
  - Used batch processing (default 50 posts via `get_posts`) to avoid memory or timeout issues. If the batch limit is reached, it schedules a single continuation event (`jobus_auto_expire_jobs_batch_continue`).
🔌 **Extensibility:** Added `jobus_enable_auto_expire_jobs` filter to toggle the feature, `jobus_auto_expire_jobs_batch_size` filter for batch control, and fires `do_action( 'jobus_job_auto_expired', $job_id )` when a job is drafted, allowing Jobus Pro or other extensions to send notifications.
✅ **Testing:** Verified syntax, tested query/batch/continuation logic via an isolated standalone PHP script that mocked WP core functions, confirming proper state transitions and hook firing.
🔄 **Compatibility:** Verified integration with `jobus.php` hook registration without altering existing Pro features.

---
*PR created automatically by Jules for task [10831399280421642449](https://jules.google.com/task/10831399280421642449) started by @mdjwel*