### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/includes/Classes/Cron/Job_Expirator.php
+++ b/includes/Classes/Cron/Job_Expirator.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Job Expirator
+ *
+ * Automatically draft jobs that have passed their deadline.
+ *
+ * @package jobus
+ */
+
+namespace jobus\includes\Classes\Cron;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Job Expirator Class.
+ */
+class Job_Expirator {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'jobus_daily_maintenance', [ $this, 'auto_expire_jobs' ] );
+		add_action( 'jobus_auto_expire_jobs_batch_continue', [ $this, 'auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Automatically expire jobs past their deadline.
+	 *
+	 * @return void
+	 */
+	public function auto_expire_jobs() {
+		// Allow disabling this automation via filter.
+		if ( ! apply_filters( 'jobus_enable_auto_expire_jobs', true ) ) {
+			return;
+		}
+
+		// Process in batches to prevent timeouts.
+		$batch_size = apply_filters( 'jobus_auto_expire_jobs_batch_size', 50 );
+
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => current_time( 'Y-m-d' ),
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+			],
+		] );
+
+		if ( empty( $expired_jobs ) ) {
+			return;
+		}
+
+		foreach ( $expired_jobs as $job_id ) {
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			// Fire action so Pro version or extensions can react (e.g., notify employer).
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+
+		// If the number of returned jobs equals the batch size, there might be more to process.
+		if ( count( $expired_jobs ) === (int) $batch_size ) {
+			wp_schedule_single_event( time() + 60, 'jobus_auto_expire_jobs_batch_continue' );
+		}
+	}
+}

--- a/jobus.php
+++ b/jobus.php
@@ -164,6 +164,7 @@ final class Jobus {
 
 		// Classes
 		new \jobus\includes\Classes\Ajax_Actions();
+		new \jobus\includes\Classes\Cron\Job_Expirator();
 
 		// Submission Classes
 		if ( $enable_candidate ) {
@@ -255,6 +256,11 @@ final class Jobus {
 
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
+
+		// Schedule cron events
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
 	}
 
 	/**
@@ -273,6 +279,10 @@ final class Jobus {
 				update_option( 'jobus_pages', $pages );
 			}
 		}
+
+		// Clear scheduled cron events
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+		wp_clear_scheduled_hook( 'jobus_auto_expire_jobs_batch_continue' );
 	}
 
 	/**


### PR DESCRIPTION
💡 **What:** A new workflow automation that runs a daily cron job to automatically draft jobs that have passed their deadline.
🎯 **Why:** Admins and employers currently must manually find and close out expired listings, creating a persistent administrative burden and leaving expired jobs visible in search results longer than intended.
⏱️ **Time Saved:** Eliminates all manual tracking of expired jobs, saving employers and site admins multiple hours per month depending on volume.
🔧 **How:** Implemented `Job_Expirator` hooked into a new `jobus_daily_maintenance` cron schedule. Uses safe batch limits (default 50) and `wp_schedule_single_event` to process large datasets without timeouts. Uses `wp_update_post` to draft the listing safely.
🔌 **Extensibility:**
- Action `jobus_job_auto_expired` fires when a job is drafted, allowing Jobus Pro to send notifications to employers.
- Filter `jobus_enable_auto_expire_jobs` allows admins to disable the automation.
- Filter `jobus_auto_expire_jobs_batch_size` allows tuning of processing limits.
✅ **Testing:** Verified logic via standalone PHP script mocking WordPress environments, tested query parameters and limits, and verified correct activation/deactivation hooks.
🔄 **Compatibility:** Fully compatible with both Jobus Free and Pro. Uses standard core functions without relying on external dependencies.

---
*PR created automatically by Jules for task [6728827223992361791](https://jules.google.com/task/6728827223992361791) started by @mdjwel*