### PR TITLE
⚒️ Forge: Prevent duplicate job applications

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,29 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Prevent duplicate applications
+		$existing_application = get_posts( [
+			'post_type'      => 'jobus_applicant',
+			'post_status'    => 'any',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'   => 'candidate_email',
+					'value' => $candidate_email,
+				],
+				[
+					'key'   => 'job_applied_for_id',
+					'value' => $job_application_id,
+				],
+			],
+		] );
+
+		if ( ! empty( $existing_application ) ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+			wp_die();
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
* 💡 **What:** Prevent candidates from submitting multiple applications for the same job.
* 🎯 **Why:** To eliminate duplicate application noise and save employers time during the application review process.
* ⏱️ **Time Saved:** Saves employers potential hours each week of filtering through duplicate or spam applications.
* 🔧 **How:** By intercepting the `job_application_form` AJAX handler in `Ajax_Actions.php` and running a fast, low-overhead meta query against the `jobus_applicant` post type to check if an entry with the exact `candidate_email` and `job_applied_for_id` already exists.
* 🔌 **Extensibility:** Standard WP hooks continue to fire; existing application checks apply transparently.
* ✅ **Testing:** Tested using mock PHP scripts simulating duplicate and new application submissions, verifying the correct branch is taken and expected JSON response is given.
* 🔄 **Compatibility:** Fully compatible with existing Jobus Pro features without altering existing data.

---
*PR created automatically by Jules for task [13740776751603540686](https://jules.google.com/task/13740776751603540686) started by @mdjwel*