### PR TITLE
⚒️ Forge: Duplicate Application Prevention

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,28 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Check for existing application to prevent duplicates
+		$existing_applications = get_posts( [
+			'post_type'      => 'jobus_applicant',
+			'post_status'    => 'any',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'   => 'candidate_email',
+					'value' => $candidate_email,
+				],
+				[
+					'key'   => 'job_applied_for_id',
+					'value' => $job_application_id,
+				],
+			],
+		] );
+
+		if ( ! empty( $existing_applications ) ) {
+			wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
💡 **What:** Added duplicate application prevention logic.
🎯 **Why:** To eliminate manual effort for employers sorting through duplicate applications and prevent candidates from accidentally applying multiple times to the same job.
⏱️ **Time Saved:** Saves employers time manually sorting applications and prevents inbox noise.
🔧 **How:** Implemented a pre-save check in `includes/Classes/Ajax_Actions.php` using a fast `get_posts` meta query for `candidate_email` and `job_applied_for_id`.
✅ **Testing:** Verified logic via a standalone mock test script confirming duplicates are blocked and initial submissions succeed. Also checked PHP syntax.

---
*PR created automatically by Jules for task [5655356888408602962](https://jules.google.com/task/5655356888408602962) started by @mdjwel*