### PR TITLE
⚒️ Forge: Duplicate application prevention

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,31 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Prevent duplicate applications
+		if ( apply_filters( 'jobus_prevent_duplicate_applications', true ) ) {
+			$existing_applications = get_posts( [
+				'post_type'      => 'jobus_applicant',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'meta_query'     => [
+					'relation' => 'AND',
+					[
+						'key'   => 'candidate_email',
+						'value' => $candidate_email,
+					],
+					[
+						'key'   => 'job_applied_for_id',
+						'value' => $job_application_id,
+					],
+				],
+				'fields'         => 'ids',
+			] );
+
+			if ( ! empty( $existing_applications ) ) {
+				wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+			}
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
⚒️ Forge: Duplicate application prevention

💡 **What:** Added duplicate application prevention logic to the `job_application_form` AJAX handler.
🎯 **Why:** Prevents candidates from applying to the same job multiple times, eliminating wasted effort and "spam" for employers who would otherwise have to review duplicate entries.
⏱️ **Time Saved:** Saves employers time sorting through redundant applications and prevents candidates from accidentally clicking submit twice and creating duplicates.
🔧 **How:** Hooked into the `jobus_job_application` AJAX handler. Performs an optimized `get_posts` query (limited to 1 result, returning only IDs) checking for an existing application with the same `candidate_email` and `job_applied_for_id`.
🔌 **Extensibility:** Introduced the `jobus_prevent_duplicate_applications` boolean filter so the feature can be toggled off programmatically if an admin wishes to allow duplicates.
✅ **Testing:** Verified via a standalone PHP mocking script simulating both new and duplicate applications. Evaluated proper early-exit flow to prevent dead code via `wp_send_json_error()`.
🔄 **Compatibility:** Placed early in the AJAX handler to short-circuit before any database writes or external hooks are fired, ensuring Pro extensions don't trigger duplicate notifications.

---
*PR created automatically by Jules for task [17812511451060695563](https://jules.google.com/task/17812511451060695563) started by @mdjwel*