### PR TITLE
⚒️ Forge: Auto-expire jobs past deadline via daily cron

### DIFF
--- a/jobus.php
+++ b/jobus.php
@@ -124,6 +124,59 @@ final class Jobus {
 		add_action( 'after_setup_theme', [ $this, 'load_csf_files' ], 20 );
 		add_action( 'admin_init', [ $this, 'plugin_default_pages_exist' ] );
 		add_action( 'after_switch_theme', [ $this, 'plugin_default_pages_exist' ] );
+
+		// Register maintenance cron hook
+		add_action( 'jobus_daily_maintenance', [ $this, 'auto_expire_jobs' ] );
+		add_action( 'jobus_auto_expire_jobs_batch_continue', [ $this, 'auto_expire_jobs' ] );
+	}
+
+	/**
+	 * Auto expire jobs past their deadline.
+	 * Runs on daily cron to draft expired jobs and fire notifications.
+	 *
+	 * @return void
+	 */
+	public function auto_expire_jobs(): void {
+		if ( ! apply_filters( 'jobus_enable_auto_expire_jobs', true ) ) {
+			return;
+		}
+
+		$batch_size = apply_filters( 'jobus_cron_batch_size', 50 );
+
+		$expired_jobs = get_posts( [
+			'post_type'      => 'jobus_job',
+			'post_status'    => 'publish',
+			'posts_per_page' => $batch_size,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => 'job_deadline',
+					'value'   => current_time( 'Y-m-d' ),
+					'compare' => '<',
+					'type'    => 'DATE',
+				],
+				[
+					'key'     => 'job_deadline',
+					'value'   => '',
+					'compare' => '!=',
+				],
+			],
+		] );
+
+		foreach ( $expired_jobs as $job_id ) {
+			wp_update_post( [
+				'ID'          => $job_id,
+				'post_status' => 'draft',
+			] );
+
+			// Fire hook for Pro notifications and extensibility
+			do_action( 'jobus_job_auto_expired', $job_id );
+		}
+
+		// If there are more jobs to process, schedule a continuation event
+		if ( count( $expired_jobs ) === $batch_size ) {
+			wp_schedule_single_event( time() + 60, 'jobus_auto_expire_jobs_batch_continue' );
+		}
 	}
 
 	/**
@@ -255,6 +308,11 @@ final class Jobus {
 
 		// Create default frontend pages depending on theme / premium status
 		$this->plugin_default_pages_exist();
+
+		// Register cron event for daily maintenance
+		if ( ! wp_next_scheduled( 'jobus_daily_maintenance' ) ) {
+			wp_schedule_event( time(), 'daily', 'jobus_daily_maintenance' );
+		}
 	}
 
 	/**
@@ -273,6 +331,10 @@ final class Jobus {
 				update_option( 'jobus_pages', $pages );
 			}
 		}
+
+		// Clear scheduled cron events
+		wp_clear_scheduled_hook( 'jobus_daily_maintenance' );
+		wp_clear_scheduled_hook( 'jobus_auto_expire_jobs_batch_continue' );
 	}
 
 	/**


### PR DESCRIPTION
💡 **What:** The workflow automation or enhancement implemented
Implemented a daily cron job (`jobus_daily_maintenance`) that automatically queries for published jobs past their `job_deadline` and sets their status to `draft`. 

🎯 **Why:** The manual pain point it eliminates
Currently, administrators or employers must manually find and close expired job listings. This eliminates that entirely.

⏱️ **Time Saved:** Estimated time savings
Saves administrators and employers hours of manual expired-job cleanup every week, ensuring job boards stay relevant and up-to-date without active management.

🔧 **How:** Implementation approach
Added a new method `auto_expire_jobs()` inside the main `Jobus` class in `jobus.php`. Hooked it into a new daily cron schedule registered on plugin activation (and cleared on deactivation). The query processes exactly 50 jobs at a time. If the limit is reached, it schedules a continuation cron job (`jobus_auto_expire_jobs_batch_continue`) 60 seconds later to process the next batch securely.

🔌 **Extensibility:** New hooks/filters added
- Filter: `jobus_enable_auto_expire_jobs` (boolean) to allow site admins to programmatically turn off this specific automation.
- Filter: `jobus_cron_batch_size` (integer) to adjust the chunk size processing limit.
- Action: `jobus_job_auto_expired` (fires per job drafted) allowing Pro notifications or other third parties to react.

✅ **Testing:** What was tested
- Used `php -l` to check code syntax.
- Created and executed a standalone script that mocked WP core, populated test job queries matching the `job_deadline` condition, and executed `jobus()->auto_expire_jobs()` successfully. 
- Ensured cron event registrations (`wp_schedule_event`) run during `activate()` and cleanup runs during `deactivate()`.

🔄 **Compatibility:** Confirmed working with Jobus Pro features
The addition of the `jobus_job_auto_expired` explicitly enables Jobus Pro to hook in and send expiry emails down the line.

---
*PR created automatically by Jules for task [6390415615989553509](https://jules.google.com/task/6390415615989553509) started by @mdjwel*