### PR TITLE
⚒️ Forge: Prevent duplicate job applications via AJAX

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,24 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Prevent duplicate applications
+		if ( apply_filters( 'jobus_prevent_duplicate_applications', true ) ) {
+			$existing = get_posts( [
+				'post_type'      => 'jobus_applicant',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'meta_query'     => [
+					[ 'key' => 'candidate_email', 'value' => $candidate_email ],
+					[ 'key' => 'job_applied_for_id', 'value' => $job_application_id ],
+				],
+				'fields' => 'ids',
+			] );
+
+			if ( ! empty( $existing ) ) {
+				wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+			}
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
Added a check in `includes/Classes/Ajax_Actions.php` to prevent duplicate applications. The logic executes prior to insertion, verifying whether the `candidate_email` and `job_applied_for_id` already exist for an application post. A new filter `jobus_prevent_duplicate_applications` controls execution.

---
*PR created automatically by Jules for task [16828881864341513304](https://jules.google.com/task/16828881864341513304) started by @mdjwel*