### PR TITLE
⚒️ Forge: Prevent duplicate job applications

### DIFF
--- a/includes/Classes/Ajax_Actions.php
+++ b/includes/Classes/Ajax_Actions.php
@@ -127,6 +127,31 @@ class Ajax_Actions {
 			wp_die();
 		}
 
+		// Prevent duplicate applications
+		if ( apply_filters( 'jobus_prevent_duplicate_applications', true ) ) {
+			$existing_application = get_posts( [
+				'post_type'      => 'jobus_applicant',
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'meta_query'     => [
+					[
+						'key'   => 'candidate_email',
+						'value' => $candidate_email,
+					],
+					[
+						'key'   => 'job_applied_for_id',
+						'value' => $job_application_id,
+					],
+				],
+				'fields'         => 'ids',
+			] );
+
+			if ( ! empty( $existing_application ) ) {
+				wp_send_json_error( [ 'message' => esc_html__( 'You have already applied for this job.', 'jobus' ) ] );
+				wp_die();
+			}
+		}
+
 		// Save the application as a new post
 		$post_title     = trim( $candidate_fname . ( ! empty( $candidate_lname ) ? ' ' . $candidate_lname : '' ) );
 		$application_id = wp_insert_post( [


### PR DESCRIPTION
⚒️ **Forge: Prevent duplicate job applications**

**What:** Implemented a workflow enhancement that prevents duplicate applications by querying for existing `jobus_applicant` posts with the same `candidate_email` and `job_applied_for_id` before inserting a new one.
**Why:** Eliminates the manual busywork for employers of reviewing duplicate applications from the same candidate for the same job.
**Time Saved:** Saves employers time filtering and reviewing duplicate applications.
**How:** A fast `get_posts` (returning `ids`) query in `includes/Classes/Ajax_Actions.php`.
**Extensibility:** Added `jobus_prevent_duplicate_applications` filter allowing it to be disabled if needed.
**Testing:** Checked with isolated tests that return an error gracefully without completing the duplicate submission.

---
*PR created automatically by Jules for task [17648085203686031144](https://jules.google.com/task/17648085203686031144) started by @mdjwel*